### PR TITLE
feat: use render without render options

### DIFF
--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -15,7 +15,9 @@ class WrapperComponent implements OnInit {
 
 export async function render<T>(
   templateOrComponent: string | Type<T>,
-  {
+  renderOptions: RenderOptions<T> = {},
+): Promise<RenderResult> {
+  const {
     detectChanges = true,
     declarations = [],
     imports = [],
@@ -24,8 +26,8 @@ export async function render<T>(
     queries,
     wrapper = WrapperComponent,
     componentProperties = {},
-  }: RenderOptions<T>,
-): Promise<RenderResult> {
+  } = renderOptions;
+
   const isTemplate = typeof templateOrComponent === 'string';
   const componentDeclarations = isTemplate ? [wrapper] : [templateOrComponent];
 

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -13,6 +13,8 @@ class WrapperComponent implements OnInit {
   }
 }
 
+export async function render<T>(template: string, renderOptions: RenderOptions<T>);
+export async function render<T>(component: Type<T>, renderOptions?: RenderOptions<T>);
 export async function render<T>(
   templateOrComponent: string | Type<T>,
   renderOptions: RenderOptions<T> = {},

--- a/projects/testing-library/tests/counter/counter.spec.ts
+++ b/projects/testing-library/tests/counter/counter.spec.ts
@@ -65,6 +65,18 @@ test('Counter actions via component syntax', async () => {
   expect(getByTestId('count').textContent).toBe('Current Count: 0');
 });
 
+test('Counter actions via component syntax without render options', async () => {
+  const { getByText, getByTestId, click } = await render(CounterComponent);
+
+  click(getByText('+'));
+  expect(getByText('Current Count: 1')).toBeTruthy();
+  expect(getByTestId('count').textContent).toBe('Current Count: 1');
+
+  click(getByText('-'));
+  expect(getByText('Current Count: 0')).toBeTruthy();
+  expect(getByTestId('count').textContent).toBe('Current Count: 0');
+});
+
 test('Counter actions via component syntax with parameters', async () => {
   const { getByText, getByTestId, click } = await render(CounterComponent, {
     declarations: [CounterComponent],


### PR DESCRIPTION
Moved object destructuring with default values to the function implementation.

Sorry, did not see any guidelines for contribution :/

closes #17 