### PR TITLE
fix: add peer dependencies

### DIFF
--- a/projects/testing-library/package.json
+++ b/projects/testing-library/package.json
@@ -23,6 +23,8 @@
   "homepage": "https://github.com/testing-library/angular-testing-library#readme",
   "peerDependencies": {
     "@angular/common": "^8.0.0",
+    "@angular/platform-browser": "^8.0.0",
+    "@angular/animations": "^8.0.0",
     "@angular/core": "^8.0.0"
   },
   "dependencies": {

--- a/projects/testing-library/package.json
+++ b/projects/testing-library/package.json
@@ -25,6 +25,7 @@
     "@angular/common": "^8.0.0",
     "@angular/platform-browser": "^8.0.0",
     "@angular/animations": "^8.0.0",
+    "@angular/router": "^8.0.0",
     "@angular/core": "^8.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Recent features (notably #40 and #48) have added additional peer dependencies that had not been added to the package.json. This is an issue when running under Bazel, where anything you do not explicitly list as a dependency is unavailable. Bazel works out the dependencies from package.json when you depend on an NPM package, thus resolving this for you when the (peer)dependencies are listed correctly.

I'm not sure if I can reproduce this in a plain Angular CLI project for you, but if needed I can provide a simple Bazel example showcasing the behaviour.