### PR TITLE
fix: don't call detectChanges when fixture is destroyed

### DIFF
--- a/projects/testing-library/tests/detect-changes.spec.ts
+++ b/projects/testing-library/tests/detect-changes.spec.ts
@@ -40,4 +40,13 @@ describe('detectChanges', () => {
 
     expect(getByTestId('button').innerHTML).toBe('Button updated after 400ms');
   }));
+
+  test('does not throw on a destroyed fixture', async () => {
+    const { getByTestId, type, fixture } = await render(FixtureComponent, { imports: [ReactiveFormsModule] });
+
+    fixture.destroy();
+
+    type(getByTestId('input'), 'What a great day!');
+    expect(getByTestId('button').innerHTML).toBe('Button');
+  });
 });

--- a/projects/testing-library/tests/fire-event.spec.ts
+++ b/projects/testing-library/tests/fire-event.spec.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { render } from '../src/public_api';
+
+@Component({
+  selector: 'fixture',
+  template: `
+    <input type="text" data-testid="input" />
+  `,
+})
+class FixtureComponent {}
+
+test('does not call detect changes when fixture is destroyed', async () => {
+  const component = await render(FixtureComponent);
+
+  component.fixture.destroy();
+
+  // should otherwise throw
+  component.input(component.getByTestId('input'), { target: { value: 'Bonjour' } });
+  component.type(component.getByTestId('input'), 'Alles klar');
+});


### PR DESCRIPTION
The `blur` event fired from `type` throws when a fixture is already destroyed.
This PR adds a check to see if the fixture isn't destroyed before calling `detectChanges`.