### PR TITLE
refactor: use screen to query elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@angular/platform-browser": "^9.0.3",
     "@angular/platform-browser-dynamic": "^9.0.3",
     "@angular/router": "^9.0.3",
-    "@ngrx/store": "^8.0.0-rc.0",
+    "@ngrx/store": "^9.0.0-rc.0",
     "@phenomnomnominal/tsquery": "^3.0.0",
     "@testing-library/dom": "^6.12.2",
     "@testing-library/user-event": "^8.1.0",

--- a/src/app/examples/00-single-component.spec.ts
+++ b/src/app/examples/00-single-component.spec.ts
@@ -1,20 +1,20 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { SingleComponent } from './00-single-component';
 
 test('renders the current value and can increment and decrement', async () => {
-  const component = await render(SingleComponent);
+  const { click } = await render(SingleComponent);
 
-  const incrementControl = component.getByText('Increment');
-  const decrementControl = component.getByText('Decrement');
-  const valueControl = component.getByTestId('value');
+  const incrementControl = screen.getByText('Increment');
+  const decrementControl = screen.getByText('Decrement');
+  const valueControl = screen.getByTestId('value');
 
   expect(valueControl.textContent).toBe('0');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
   expect(valueControl.textContent).toBe('2');
 
-  component.click(decrementControl);
+  click(decrementControl);
   expect(valueControl.textContent).toBe('1');
 });

--- a/src/app/examples/01-nested-component.spec.ts
+++ b/src/app/examples/01-nested-component.spec.ts
@@ -1,22 +1,22 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { NestedButtonComponent, NestedValueComponent, NestedContainerComponent } from './01-nested-component';
 
 test('renders the current value and can increment and decrement', async () => {
-  const component = await render(NestedContainerComponent, {
+  const { click } = await render(NestedContainerComponent, {
     declarations: [NestedButtonComponent, NestedValueComponent],
   });
 
-  const incrementControl = component.getByText('Increment');
-  const decrementControl = component.getByText('Decrement');
-  const valueControl = component.getByTestId('value');
+  const incrementControl = screen.getByText('Increment');
+  const decrementControl = screen.getByText('Decrement');
+  const valueControl = screen.getByTestId('value');
 
   expect(valueControl.textContent).toBe('0');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
   expect(valueControl.textContent).toBe('2');
 
-  component.click(decrementControl);
+  click(decrementControl);
   expect(valueControl.textContent).toBe('1');
 });

--- a/src/app/examples/02-input-output.spec.ts
+++ b/src/app/examples/02-input-output.spec.ts
@@ -1,11 +1,11 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { InputOutputComponent } from './02-input-output';
 
 test('is possible to set input and listen for output', async () => {
   const sendValue = jest.fn();
 
-  const component = await render(InputOutputComponent, {
+  const { click } = await render(InputOutputComponent, {
     componentProperties: {
       value: 47,
       sendValue: {
@@ -14,18 +14,18 @@ test('is possible to set input and listen for output', async () => {
     },
   });
 
-  const incrementControl = component.getByText('Increment');
-  const valueControl = component.getByTestId('value');
-  const sendControl = component.getByText('Send');
+  const incrementControl = screen.getByText('Increment');
+  const valueControl = screen.getByTestId('value');
+  const sendControl = screen.getByText('Send');
 
   expect(valueControl.textContent).toBe('47');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
-  component.click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
   expect(valueControl.textContent).toBe('50');
 
-  component.click(sendControl);
+  click(sendControl);
   expect(sendValue).toHaveBeenCalledTimes(1);
   expect(sendValue).toHaveBeenCalledWith(50);
 });

--- a/src/app/examples/03-forms.spec.ts
+++ b/src/app/examples/03-forms.spec.ts
@@ -1,35 +1,35 @@
 import { ReactiveFormsModule } from '@angular/forms';
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { FormsComponent } from './03-forms';
 
 test('is possible to fill in a form and verify error messages (with the help of jest-dom https://testing-library.com/docs/ecosystem-jest-dom)', async () => {
-  const component = await render(FormsComponent, {
+  const { type, blur, selectOptions } = await render(FormsComponent, {
     imports: [ReactiveFormsModule],
   });
 
-  const nameControl = component.getByLabelText('Name');
-  const scoreControl = component.getByLabelText(/score/i);
-  const colorControl = component.getByLabelText('color', { exact: false });
-  const errors = component.getByRole('alert');
+  const nameControl = screen.getByLabelText('Name');
+  const scoreControl = screen.getByLabelText(/score/i);
+  const colorControl = screen.getByLabelText('color', { exact: false });
+  const errors = screen.getByRole('alert');
 
-  expect(errors).toContainElement(component.queryByText('name is required'));
-  expect(errors).toContainElement(component.queryByText('score must be greater than 1'));
-  expect(errors).toContainElement(component.queryByText('color is required'));
+  expect(errors).toContainElement(screen.queryByText('name is required'));
+  expect(errors).toContainElement(screen.queryByText('score must be greater than 1'));
+  expect(errors).toContainElement(screen.queryByText('color is required'));
 
   expect(nameControl).toBeInvalid();
-  component.type(nameControl, 'Tim');
-  component.type(scoreControl, '12');
-  component.blur(scoreControl);
-  component.selectOptions(colorControl, 'Green');
+  type(nameControl, 'Tim');
+  type(scoreControl, '12');
+  blur(scoreControl);
+  selectOptions(colorControl, 'Green');
 
-  expect(component.queryByText('name is required')).not.toBeInTheDocument();
-  expect(component.queryByText('score must be lesser than 10')).toBeInTheDocument();
-  expect(component.queryByText('color is required')).not.toBeInTheDocument();
+  expect(screen.queryByText('name is required')).not.toBeInTheDocument();
+  expect(screen.queryByText('score must be lesser than 10')).toBeInTheDocument();
+  expect(screen.queryByText('color is required')).not.toBeInTheDocument();
 
   expect(scoreControl).toBeInvalid();
-  component.type(scoreControl, 7);
-  component.blur(scoreControl);
+  type(scoreControl, 7);
+  blur(scoreControl);
   expect(scoreControl).toBeValid();
 
   expect(errors).not.toBeInTheDocument();
@@ -38,7 +38,7 @@ test('is possible to fill in a form and verify error messages (with the help of 
   expect(scoreControl).toHaveValue(7);
   expect(colorControl).toHaveValue('G');
 
-  const form = component.getByTestId('my-form');
+  const form = screen.getByTestId('my-form');
   expect(form).toHaveFormValues({
     name: 'Tim',
     score: 7,

--- a/src/app/examples/04-forms-with-material.spec.ts
+++ b/src/app/examples/04-forms-with-material.spec.ts
@@ -1,33 +1,33 @@
 import { ReactiveFormsModule } from '@angular/forms';
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { MaterialModule } from '../material.module';
 import { MaterialFormsComponent } from './04-forms-with-material';
 
 test('is possible to fill in a form and verify error messages (with the help of jest-dom https://testing-library.com/docs/ecosystem-jest-dom)', async () => {
-  const component = await render(MaterialFormsComponent, {
+  const { type, selectOptions, fixture } = await render(MaterialFormsComponent, {
     imports: [ReactiveFormsModule, MaterialModule],
   });
 
-  const nameControl = component.getByPlaceholderText('Name');
-  const scoreControl = component.getByPlaceholderText(/score/i);
-  const colorControl = component.getByPlaceholderText('color', { exact: false });
-  const errors = component.getByRole('alert');
+  const nameControl = screen.getByPlaceholderText('Name');
+  const scoreControl = screen.getByPlaceholderText(/score/i);
+  const colorControl = screen.getByPlaceholderText('color', { exact: false });
+  const errors = screen.getByRole('alert');
 
-  expect(errors).toContainElement(component.queryByText('name is required'));
-  expect(errors).toContainElement(component.queryByText('score must be greater than 1'));
-  expect(errors).toContainElement(component.queryByText('color is required'));
+  expect(errors).toContainElement(screen.queryByText('name is required'));
+  expect(errors).toContainElement(screen.queryByText('score must be greater than 1'));
+  expect(errors).toContainElement(screen.queryByText('color is required'));
 
-  component.type(nameControl, 'Tim');
-  component.type(scoreControl, 12);
-  component.selectOptions(colorControl, 'Green');
+  type(nameControl, 'Tim');
+  type(scoreControl, 12);
+  selectOptions(colorControl, 'Green');
 
-  expect(component.queryByText('name is required')).not.toBeInTheDocument();
-  expect(component.queryByText('score must be lesser than 10')).toBeInTheDocument();
-  expect(component.queryByText('color is required')).not.toBeInTheDocument();
+  expect(screen.queryByText('name is required')).not.toBeInTheDocument();
+  expect(screen.queryByText('score must be lesser than 10')).toBeInTheDocument();
+  expect(screen.queryByText('color is required')).not.toBeInTheDocument();
 
   expect(scoreControl).toBeInvalid();
-  component.type(scoreControl, 7);
+  type(scoreControl, 7);
   expect(scoreControl).toBeValid();
 
   expect(errors).not.toBeInTheDocument();
@@ -35,12 +35,12 @@ test('is possible to fill in a form and verify error messages (with the help of 
   expect(nameControl).toHaveValue('Tim');
   expect(scoreControl).toHaveValue(7);
 
-  const form = component.getByTestId('my-form');
+  const form = screen.getByTestId('my-form');
   expect(form).toHaveFormValues({
     name: 'Tim',
     score: 7,
   });
 
   // not added to the form?
-  expect((component.fixture.componentInstance as MaterialFormsComponent).form.get('color').value).toBe('G');
+  expect((fixture.componentInstance as MaterialFormsComponent).form.get('color').value).toBe('G');
 });

--- a/src/app/examples/05-component-provider.spec.ts
+++ b/src/app/examples/05-component-provider.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { provideMock, Mock, createMock } from '@testing-library/angular/jest-utils';
 
 import { ComponentWithProviderComponent, CounterService } from './05-component-provider';
 
 test('renders the current value and can increment and decrement', async () => {
-  const component = await render(ComponentWithProviderComponent, {
+  const { click } = await render(ComponentWithProviderComponent, {
     componentProviders: [
       {
         provide: CounterService,
@@ -14,17 +14,17 @@ test('renders the current value and can increment and decrement', async () => {
     ],
   });
 
-  const incrementControl = component.getByText('Increment');
-  const decrementControl = component.getByText('Decrement');
-  const valueControl = component.getByTestId('value');
+  const incrementControl = screen.getByText('Increment');
+  const decrementControl = screen.getByText('Decrement');
+  const valueControl = screen.getByTestId('value');
 
   expect(valueControl.textContent).toBe('0');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
   expect(valueControl.textContent).toBe('2');
 
-  component.click(decrementControl);
+  click(decrementControl);
   expect(valueControl.textContent).toBe('1');
 });
 
@@ -35,7 +35,7 @@ test('renders the current value and can increment and decrement with a mocked je
   counter.decrement.mockImplementation(() => (fakeCounterValue -= 10));
   counter.value.mockImplementation(() => fakeCounterValue);
 
-  const component = await render(ComponentWithProviderComponent, {
+  const { click } = await render(ComponentWithProviderComponent, {
     componentProviders: [
       {
         provide: CounterService,
@@ -44,33 +44,33 @@ test('renders the current value and can increment and decrement with a mocked je
     ],
   });
 
-  const incrementControl = component.getByText('Increment');
-  const decrementControl = component.getByText('Decrement');
-  const valueControl = component.getByTestId('value');
+  const incrementControl = screen.getByText('Increment');
+  const decrementControl = screen.getByText('Decrement');
+  const valueControl = screen.getByTestId('value');
 
   expect(valueControl.textContent).toBe('50');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
   expect(valueControl.textContent).toBe('70');
 
-  component.click(decrementControl);
+  click(decrementControl);
   expect(valueControl.textContent).toBe('60');
 });
 
 test('renders the current value and can increment and decrement with provideMocked from jest-utils', async () => {
-  const component = await render(ComponentWithProviderComponent, {
+  const { click } = await render(ComponentWithProviderComponent, {
     componentProviders: [provideMock(CounterService)],
   });
 
-  const incrementControl = component.getByText('Increment');
-  const decrementControl = component.getByText('Decrement');
+  const incrementControl = screen.getByText('Increment');
+  const decrementControl = screen.getByText('Decrement');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
-  component.click(decrementControl);
+  click(incrementControl);
+  click(incrementControl);
+  click(decrementControl);
 
-  const counterService = TestBed.get<CounterService>(CounterService) as Mock<CounterService>;
+  const counterService = TestBed.inject(CounterService) as Mock<CounterService>;
   expect(counterService.increment).toHaveBeenCalledTimes(2);
   expect(counterService.decrement).toHaveBeenCalledTimes(1);
 });

--- a/src/app/examples/06-with-ngrx-store.spec.ts
+++ b/src/app/examples/06-with-ngrx-store.spec.ts
@@ -1,10 +1,10 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 import { StoreModule } from '@ngrx/store';
 
 import { WithNgRxStoreComponent, reducer } from './06-with-ngrx-store';
 
 test('works with ngrx store', async () => {
-  const component = await render(WithNgRxStoreComponent, {
+  const { click } = await render(WithNgRxStoreComponent, {
     imports: [
       StoreModule.forRoot(
         {
@@ -17,16 +17,16 @@ test('works with ngrx store', async () => {
     ],
   });
 
-  const incrementControl = component.getByText('Increment');
-  const decrementControl = component.getByText('Decrement');
-  const valueControl = component.getByTestId('value');
+  const incrementControl = screen.getByText('Increment');
+  const decrementControl = screen.getByText('Decrement');
+  const valueControl = screen.getByTestId('value');
 
   expect(valueControl.textContent).toBe('0');
 
-  component.click(incrementControl);
-  component.click(incrementControl);
+  click(incrementControl);
+  click(incrementControl);
   expect(valueControl.textContent).toBe('20');
 
-  component.click(decrementControl);
+  click(decrementControl);
   expect(valueControl.textContent).toBe('10');
 });

--- a/src/app/examples/07-with-ngrx-mock-store.spec.ts
+++ b/src/app/examples/07-with-ngrx-mock-store.spec.ts
@@ -1,12 +1,12 @@
-import { render } from '@testing-library/angular';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
-
-import { WithNgRxMockStoreComponent, selectItems } from './07-with-ngrx-mock-store';
 import { TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { render, screen } from '@testing-library/angular';
+
+import { WithNgRxMockStoreComponent, selectItems } from './07-with-ngrx-mock-store';
 
 test('works with provideMockStore', async () => {
-  const component = await render(WithNgRxMockStoreComponent, {
+  const { click } = await render(WithNgRxMockStoreComponent, {
     providers: [
       provideMockStore({
         selectors: [
@@ -19,11 +19,11 @@ test('works with provideMockStore', async () => {
     ],
   });
 
-  const store = TestBed.get(Store) as MockStore<any>;
+  const store = TestBed.inject(MockStore);
   store.dispatch = jest.fn();
 
-  component.getByText('Four');
-  component.click(component.getByText('Seven'));
+  screen.getByText('Four');
+  click(screen.getByText('Seven'));
 
   expect(store.dispatch).toBeCalledWith({ type: '[Item List] send', item: 'Seven' });
 });

--- a/src/app/examples/08-directive.spec.ts
+++ b/src/app/examples/08-directive.spec.ts
@@ -1,29 +1,29 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { SpoilerDirective } from './08-directive';
 
 test('it is possible to test directives', async () => {
-  const component = await render(SpoilerDirective, {
+  const { mouseOver, mouseLeave, debugElement } = await render(SpoilerDirective, {
     template: `<div appSpoiler></div>`,
   });
 
-  expect(component.queryByText('I am visible now...')).not.toBeInTheDocument();
-  expect(component.queryByText('SPOILER')).toBeInTheDocument();
+  expect(screen.queryByText('I am visible now...')).not.toBeInTheDocument();
+  expect(screen.queryByText('SPOILER')).toBeInTheDocument();
 
-  component.mouseOver(component.debugElement.nativeElement);
-  expect(component.queryByText('SPOILER')).not.toBeInTheDocument();
-  expect(component.queryByText('I am visible now...')).toBeInTheDocument();
+  mouseOver(debugElement.nativeElement);
+  expect(screen.queryByText('SPOILER')).not.toBeInTheDocument();
+  expect(screen.queryByText('I am visible now...')).toBeInTheDocument();
 
-  component.mouseLeave(component.debugElement.nativeElement);
-  expect(component.queryByText('SPOILER')).toBeInTheDocument();
-  expect(component.queryByText('I am visible now...')).not.toBeInTheDocument();
+  mouseLeave(debugElement.nativeElement);
+  expect(screen.queryByText('SPOILER')).toBeInTheDocument();
+  expect(screen.queryByText('I am visible now...')).not.toBeInTheDocument();
 });
 
 test('it is possible to test directives with props', async () => {
   const hidden = 'SPOILER ALERT';
   const visible = 'There is nothing to see here ...';
 
-  const component = await render(SpoilerDirective, {
+  const { mouseOver, mouseLeave } = await render(SpoilerDirective, {
     template: `<div appSpoiler [hidden]="hidden" [visible]="visible"></div>`,
     componentProperties: {
       hidden,
@@ -31,34 +31,34 @@ test('it is possible to test directives with props', async () => {
     },
   });
 
-  expect(component.queryByText(visible)).not.toBeInTheDocument();
-  expect(component.queryByText(hidden)).toBeInTheDocument();
+  expect(screen.queryByText(visible)).not.toBeInTheDocument();
+  expect(screen.queryByText(hidden)).toBeInTheDocument();
 
-  component.mouseOver(component.queryByText(hidden));
-  expect(component.queryByText(hidden)).not.toBeInTheDocument();
-  expect(component.queryByText(visible)).toBeInTheDocument();
+  mouseOver(screen.queryByText(hidden));
+  expect(screen.queryByText(hidden)).not.toBeInTheDocument();
+  expect(screen.queryByText(visible)).toBeInTheDocument();
 
-  component.mouseLeave(component.queryByText(visible));
-  expect(component.queryByText(hidden)).toBeInTheDocument();
-  expect(component.queryByText(visible)).not.toBeInTheDocument();
+  mouseLeave(screen.queryByText(visible));
+  expect(screen.queryByText(hidden)).toBeInTheDocument();
+  expect(screen.queryByText(visible)).not.toBeInTheDocument();
 });
 
 test('it is possible to test directives with props in template', async () => {
   const hidden = 'SPOILER ALERT';
   const visible = 'There is nothing to see here ...';
 
-  const component = await render(SpoilerDirective, {
+  const { mouseLeave, mouseOver } = await render(SpoilerDirective, {
     template: `<div appSpoiler hidden="${hidden}" visible="${visible}"></div>`,
   });
 
-  expect(component.queryByText(visible)).not.toBeInTheDocument();
-  expect(component.queryByText(hidden)).toBeInTheDocument();
+  expect(screen.queryByText(visible)).not.toBeInTheDocument();
+  expect(screen.queryByText(hidden)).toBeInTheDocument();
 
-  component.mouseOver(component.queryByText(hidden));
-  expect(component.queryByText(hidden)).not.toBeInTheDocument();
-  expect(component.queryByText(visible)).toBeInTheDocument();
+  mouseOver(screen.queryByText(hidden));
+  expect(screen.queryByText(hidden)).not.toBeInTheDocument();
+  expect(screen.queryByText(visible)).toBeInTheDocument();
 
-  component.mouseLeave(component.queryByText(visible));
-  expect(component.queryByText(hidden)).toBeInTheDocument();
-  expect(component.queryByText(visible)).not.toBeInTheDocument();
+  mouseLeave(screen.queryByText(visible));
+  expect(screen.queryByText(hidden)).toBeInTheDocument();
+  expect(screen.queryByText(visible)).not.toBeInTheDocument();
 });

--- a/src/app/examples/09-router.spec.ts
+++ b/src/app/examples/09-router.spec.ts
@@ -1,11 +1,9 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { DetailComponent, MasterComponent, HiddenDetailComponent } from './09-router';
-import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
 
 test('it can navigate to routes', async () => {
-  const component = await render(MasterComponent, {
+  const { navigate } = await render(MasterComponent, {
     declarations: [DetailComponent, HiddenDetailComponent],
     routes: [
       {
@@ -24,27 +22,27 @@ test('it can navigate to routes', async () => {
     ],
   });
 
-  expect(component.queryByText(/Detail one/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Detail one/i)).not.toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Load one/));
-  expect(component.queryByText(/Detail one/i)).toBeInTheDocument();
+  await navigate(screen.getByText(/Load one/));
+  expect(screen.queryByText(/Detail one/i)).toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Load three/));
-  expect(component.queryByText(/Detail one/i)).not.toBeInTheDocument();
-  expect(component.queryByText(/Detail three/i)).toBeInTheDocument();
+  await navigate(screen.getByText(/Load three/));
+  expect(screen.queryByText(/Detail one/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Detail three/i)).toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Back to parent/));
-  expect(component.queryByText(/Detail three/i)).not.toBeInTheDocument();
+  await navigate(screen.getByText(/Back to parent/));
+  expect(screen.queryByText(/Detail three/i)).not.toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Load two/));
-  expect(component.queryByText(/Detail two/i)).toBeInTheDocument();
-  await component.navigate(component.getByText(/hidden x/));
-  expect(component.queryByText(/You found the treasure!/i)).toBeInTheDocument();
+  await navigate(screen.getByText(/Load two/));
+  expect(screen.queryByText(/Detail two/i)).toBeInTheDocument();
+  await navigate(screen.getByText(/hidden x/));
+  expect(screen.queryByText(/You found the treasure!/i)).toBeInTheDocument();
 });
 
 test('it can navigate to routes with a base path', async () => {
   const basePath = 'base';
-  const component = await render(MasterComponent, {
+  const { navigate } = await render(MasterComponent, {
     declarations: [DetailComponent, HiddenDetailComponent],
     routes: [
       {
@@ -63,20 +61,20 @@ test('it can navigate to routes with a base path', async () => {
     ],
   });
 
-  expect(component.queryByText(/Detail one/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Detail one/i)).not.toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Load one/), basePath);
-  expect(component.queryByText(/Detail one/i)).toBeInTheDocument();
+  await navigate(screen.getByText(/Load one/), basePath);
+  expect(screen.queryByText(/Detail one/i)).toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Load three/), basePath);
-  expect(component.queryByText(/Detail one/i)).not.toBeInTheDocument();
-  expect(component.queryByText(/Detail three/i)).toBeInTheDocument();
+  await navigate(screen.getByText(/Load three/), basePath);
+  expect(screen.queryByText(/Detail one/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Detail three/i)).toBeInTheDocument();
 
-  await component.navigate(component.getByText(/Back to parent/));
-  expect(component.queryByText(/Detail three/i)).not.toBeInTheDocument();
+  await navigate(screen.getByText(/Back to parent/));
+  expect(screen.queryByText(/Detail three/i)).not.toBeInTheDocument();
 
-  await component.navigate('base/detail/two'); // possible to just use strings
-  expect(component.queryByText(/Detail two/i)).toBeInTheDocument();
-  await component.navigate('/hidden-detail', basePath);
-  expect(component.queryByText(/You found the treasure!/i)).toBeInTheDocument();
+  await navigate('base/detail/two'); // possible to just use strings
+  expect(screen.queryByText(/Detail two/i)).toBeInTheDocument();
+  await navigate('/hidden-detail', basePath);
+  expect(screen.queryByText(/You found the treasure!/i)).toBeInTheDocument();
 });

--- a/src/app/examples/10-inject-token-dependency.spec.ts
+++ b/src/app/examples/10-inject-token-dependency.spec.ts
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/angular';
+import { render, screen } from '@testing-library/angular';
 
 import { DataInjectedComponent, DATA } from './10-inject-token-dependency';
 
 test('injects data into the component', async () => {
-  const component = await render(DataInjectedComponent, {
+  await render(DataInjectedComponent, {
     providers: [
       {
         provide: DATA,
@@ -12,5 +12,5 @@ test('injects data into the component', async () => {
     ],
   });
 
-  expect(component.getByText(/Hello boys and girls/i)).toBeInTheDocument();
+  expect(screen.getByText(/Hello boys and girls/i)).toBeInTheDocument();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,10 +1224,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@ngrx/store@^8.0.0-rc.0":
-  version "8.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@ngrx/store/-/store-8.0.0-rc.0.tgz#3ec0ca8986fb3cb2b246cab0c851833a21f9a134"
-  integrity sha512-TL+2BERGH4DET8sIW1D02wkmKxlnVXWezm1OkQJd2Q/6h6MwZBd8SeDpuiEIUHr2/1BPUyPNe1bj+vemeiwWrw==
+"@ngrx/store@^9.0.0-rc.0":
+  version "9.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@ngrx/store/-/store-9.0.0-rc.0.tgz#49c07feecbf6b5ed929382716170e0be4e5627c3"
+  integrity sha512-+KghtX8QZ1maweTGtyV1CtI8N3jDQXrxf5hMngOVR9Bu6KuLl/RbnSSPTAGSK3wbVZ13CYebN3OECVhz1FDuzQ==
 
 "@ngtools/webpack@9.0.3":
   version "9.0.3"


### PR DESCRIPTION
The Testing Library encourages the usage of `screen` to query DOM elements.
See https://testing-library.com/docs/dom-testing-library/api-queries#screen for more info.