### PR TITLE
feat: update DOM Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^9.0.3",
     "@ngrx/store": "^9.0.0-rc.0",
     "@phenomnomnominal/tsquery": "^3.0.0",
-    "@testing-library/dom": "^6.12.2",
+    "@testing-library/dom": "^7.0.0-beta.3",
     "@testing-library/user-event": "^8.1.0",
     "core-js": "^3.1.3",
     "rxjs": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^9.0.3",
     "@ngrx/store": "^9.0.0-rc.0",
     "@phenomnomnominal/tsquery": "^3.0.0",
-    "@testing-library/dom": "^7.0.0-beta.3",
+    "@testing-library/dom": "^7.0.0-beta.4",
     "@testing-library/user-event": "^8.1.0",
     "core-js": "^3.1.3",
     "rxjs": "^6.5.4",

--- a/projects/testing-library/package.json
+++ b/projects/testing-library/package.json
@@ -29,7 +29,7 @@
     "@angular/core": "^9.0.0"
   },
   "dependencies": {
-    "@testing-library/dom": "^6.12.2",
+    "@testing-library/dom": "^7.0.0-beta.3",
     "@testing-library/user-event": "^8.1.0",
     "@phenomnomnominal/tsquery": "^3.0.0",
     "tslint": "^5.16.0"

--- a/projects/testing-library/package.json
+++ b/projects/testing-library/package.json
@@ -29,7 +29,7 @@
     "@angular/core": "^9.0.0"
   },
   "dependencies": {
-    "@testing-library/dom": "^7.0.0-beta.3",
+    "@testing-library/dom": "^7.0.0-beta.4",
     "@testing-library/user-event": "^8.1.0",
     "@phenomnomnominal/tsquery": "^3.0.0",
     "tslint": "^5.16.0"

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -6,6 +6,7 @@ import {
   FireObject,
   Queries,
   queries,
+  wait,
   waitForElement,
   waitForElementToBeRemoved,
   waitForDomChange,
@@ -67,6 +68,7 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType>
    */
   rerender: (componentProperties: Partial<ComponentType>) => void;
   /**
+   * @deprecated `waitForDomChange` has been deprecated. Use `wait` instead: https://testing-library.com/docs/dom-testing-library/api-async#wait.
    * @description
    * Wait for the DOM to change.
    *
@@ -74,6 +76,7 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType>
    */
   waitForDomChange: typeof waitForDomChange;
   /**
+   * @deprecated `waitForElement` has been deprecated. Use a `find*` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use `wait` instead (it's the same API, so you can find/replace): https://testing-library.com/docs/dom-testing-library/api-async#wait
    * @description
    * Wait for DOM elements to appear, disappear, or change.
    *
@@ -87,6 +90,13 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType>
    * For more info see https://testing-library.com/docs/dom-testing-library/api-async#waitforelementtoberemoved
    */
   waitForElementToBeRemoved: typeof waitForElementToBeRemoved;
+  /**
+   * @description
+   * When in need to wait for non-deterministic periods of time you can use wait, to wait for your expectations to pass.
+   *
+   * For more info see https://testing-library.com/docs/dom-testing-library/api-async#wait
+   */
+  wait: typeof wait;
 }
 
 export interface RenderComponentOptions<ComponentType, Q extends Queries = typeof queries> {

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -128,7 +128,7 @@ export async function render<SutType, WrapperType = SutType>(
   };
 
   function componentWait(
-    callback: () => void,
+    callback,
     options: {
       container?: HTMLElement;
       timeout?: number;
@@ -162,7 +162,7 @@ export async function render<SutType, WrapperType = SutType>(
     return waitForDomChange(options).finally(() => clearInterval(interval));
   }
 
-  function componentWaitForElement<Result>(
+  function componentWaitForElement<Result = HTMLElement>(
     callback: () => Result,
     options: {
       container?: HTMLElement;
@@ -180,7 +180,7 @@ export async function render<SutType, WrapperType = SutType>(
     return waitForElement(callback, options).finally(() => clearInterval(interval));
   }
 
-  function componentWaitForElementToBeRemoved<Result>(
+  function componentWaitForElementToBeRemoved<Result = HTMLElement>(
     callback: () => Result,
     options: {
       container?: HTMLElement;

--- a/projects/testing-library/tests/wait.spec.ts
+++ b/projects/testing-library/tests/wait.spec.ts
@@ -1,0 +1,39 @@
+import { Component } from '@angular/core';
+import { timer } from 'rxjs';
+import { render } from '../src/public_api';
+
+@Component({
+  selector: 'fixture',
+  template: `
+    <button data-testid="button" (click)="load()">Load</button>
+    <div>{{ result }}</div>
+  `,
+})
+class FixtureComponent {
+  result = '';
+
+  load() {
+    timer(500).subscribe(() => (this.result = 'Success'));
+  }
+}
+
+test('waits for assertion to become true', async () => {
+  const { queryByText, getByTestId, click, wait, getByText } = await render(FixtureComponent);
+
+  expect(queryByText('Success')).toBeNull();
+
+  click(getByTestId('button'));
+
+  await wait(() => getByText('Success'));
+  getByText('Success');
+});
+
+test('allows to override options', async () => {
+  const { getByTestId, click, wait, getByText } = await render(FixtureComponent);
+
+  click(getByTestId('button'));
+
+  await expect(wait(() => getByText('Success'), { timeout: 200 })).rejects.toThrow(
+    /Unable to find an element with the text: Success/i,
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,10 +1525,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^7.0.0-beta.3":
-  version "7.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.0.0-beta.3.tgz#ff6a970e362451ba811de6218726ba6286bb49e9"
-  integrity sha512-RDSQ+j10SGgLKt5K6TkRSH6/mGnaDWvaEkMxN6c20c0o6ZhqDntyB/XUHk4WDvAQMFGoul2SeKfg9dLvC7dZZA==
+"@testing-library/dom@^7.0.0-beta.4":
+  version "7.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.0.0-beta.4.tgz#611dc2110552e41d0ae8720a09261e229d77e991"
+  integrity sha512-Lv+wttj/aVnSvykV9Qw5BK60Na5IAjz75Sy5TYxdFLCakaCj4VXAtveg2pACqI6Dh0aqKF0oThq9KJKEhccUXw==
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@types/testing-library__dom" "^6.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,14 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/runtime-corejs3@^7.7.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz#ccc4e042e2fae419c67fa709567e5d2179ed3940"
+  integrity sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.0.0":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
@@ -983,7 +991,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3":
+"@babel/runtime@^7.6.3", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
@@ -1223,6 +1231,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@jest/types@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
+  integrity sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
 
 "@ngrx/store@^9.0.0-rc.0":
   version "9.0.0-rc.0"
@@ -1495,11 +1513,6 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
-
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1512,17 +1525,16 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^6.12.2":
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.12.2.tgz#5d549acf43f2e0c23b2abfd4e36d65594c3b2741"
-  integrity sha512-KCnvHra5fV+wDxg3wJObGvZFxq7v1DJt829GNFLuRDjKxVNc/B5AdsylNF5PMHFbWMXDsHwM26d2NZcZO9KjbQ==
+"@testing-library/dom@^7.0.0-beta.3":
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.0.0-beta.3.tgz#ff6a970e362451ba811de6218726ba6286bb49e9"
+  integrity sha512-RDSQ+j10SGgLKt5K6TkRSH6/mGnaDWvaEkMxN6c20c0o6ZhqDntyB/XUHk4WDvAQMFGoul2SeKfg9dLvC7dZZA==
   dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.0.0"
-    aria-query "3.0.0"
-    pretty-format "^24.9.0"
-    wait-for-expect "^3.0.0"
+    "@babel/runtime" "^7.8.4"
+    "@types/testing-library__dom" "^6.12.1"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.3.0"
+    pretty-format "^25.1.0"
 
 "@testing-library/jest-dom@^4.1.0":
   version "4.1.0"
@@ -1700,10 +1712,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/testing-library__dom@^6.0.0":
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.12.0.tgz#7d3b9e1ea7c1bda249b08d3b2dee8bb08a57976b"
-  integrity sha512-PQ/gzABzc53T68RldZ/sJHKCihtP9ofU8XIgOk+H7tlfoCRdg9mqICio5Fo8j3Z8wo+pOfuDsuPprWsn3YtVmA==
+"@types/testing-library__dom@^6.12.1":
+  version "6.12.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.12.1.tgz#37af28fae051f9e3feed5684535b1540c97ae28b"
+  integrity sha512-cgqnEjxKk31tQt29j4baSWaZPNjQf3bHalj2gcHQTpW5SuHRal76gOpF0vypeEo6o+sS5inOvvNdzLY0B3FB2A==
   dependencies:
     pretty-format "^24.3.0"
 
@@ -1730,6 +1742,13 @@
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
   integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
+  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2204,13 +2223,21 @@ argv-formatter@~1.0.0:
   resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
   integrity sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=
 
-aria-query@3.0.0, aria-query@^3.0.0:
+aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
+  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
+  dependencies:
+    "@babel/runtime" "^7.7.4"
+    "@babel/runtime-corejs3" "^7.7.4"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -3704,6 +3731,11 @@ core-js-compat@^3.6.0:
     browserslist "^4.8.3"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
+
 core-js@3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.0.tgz#2b854e451de1967d1e29896025cdc13a2518d9ea"
@@ -4374,6 +4406,11 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+dom-accessibility-api@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
+  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
 dom-serializer@0:
   version "0.2.2"
@@ -10076,6 +10113,16 @@ pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
+  integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
+  dependencies:
+    "@jest/types" "^25.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -10327,6 +10374,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.12.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
 react-is@^16.8.4:
   version "16.8.6"
@@ -12833,11 +12885,6 @@ w3c-xmlserializer@^1.0.1:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
Updates DOM Testing Library.

Adds the `wait` method and deprecates the `waitForDomChange` and `waitForElement` methods.