### PR TITLE
fix: use testbed.inject instead of testbed.get

### DIFF
--- a/projects/jest-utils/tests/create-mock.spec.ts
+++ b/projects/jest-utils/tests/create-mock.spec.ts
@@ -35,7 +35,7 @@ it('provides a mock service', async () => {
   const { click, getByText } = await render(FixtureComponent, {
     providers: [provideMock(FixtureService)],
   });
-  const service = TestBed.get<FixtureService>(FixtureService);
+  const service = TestBed.inject(FixtureService);
 
   click(getByText('Print'));
   expect(service.print).toHaveBeenCalledTimes(1);
@@ -46,7 +46,7 @@ it('is possible to write a mock implementation', async done => {
     providers: [provideMock(FixtureService)],
   });
 
-  const service = TestBed.get<FixtureService>(FixtureService) as Mock<FixtureService>;
+  const service = TestBed.inject(FixtureService) as Mock<FixtureService>;
   service.print.mockImplementation(() => done());
 
   click(getByText('Print'));

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -56,7 +56,7 @@ describe('excludeComponentDeclaration', () => {
 describe('animationModule', () => {
   test('adds NoopAnimationsModule by default', async () => {
     await render(FixtureComponent);
-    const noopAnimationsModule = TestBed.get<NoopAnimationsModule>(NoopAnimationsModule);
+    const noopAnimationsModule = TestBed.inject(NoopAnimationsModule);
     expect(noopAnimationsModule).toBeDefined();
   });
 
@@ -65,9 +65,9 @@ describe('animationModule', () => {
       imports: [BrowserAnimationsModule],
     });
 
-    const browserAnimationsModule = TestBed.get<BrowserAnimationsModule>(BrowserAnimationsModule);
+    const browserAnimationsModule = TestBed.inject(BrowserAnimationsModule);
     expect(browserAnimationsModule).toBeDefined();
 
-    expect(() => TestBed.get<NoopAnimationsModule>(NoopAnimationsModule)).toThrow();
+    expect(() => TestBed.inject(NoopAnimationsModule)).toThrow();
   });
 });


### PR DESCRIPTION
`TestBed.get` is deprecated in favor of `TestBed.inject`