### PR TITLE
test: add ng-content example

### DIFF
--- a/src/app/examples/11-ng-content.spec.ts
+++ b/src/app/examples/11-ng-content.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
+
+import { CellComponent } from './11-ng-content';
+
+test('it is posible to test ng-content without selector', async () => {
+  const projection = 'it should be showed into a p element!';
+
+  TestBed.overrideComponent(CellComponent, { set: { selector: 'cell' } });
+  await render(CellComponent, {
+    template: `<cell data-testid="one-cell-with-ng-content">${projection}</cell>`,
+  });
+
+  expect(screen.getByText(projection)).toBeInTheDocument();
+  expect(screen.getByTestId('one-cell-with-ng-content')).toContainHTML(`<p>${projection}</p>`);
+});

--- a/src/app/examples/11-ng-content.ts
+++ b/src/app/examples/11-ng-content.ts
@@ -1,0 +1,11 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  template: `
+    <p>
+      <ng-content></ng-content>
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CellComponent {}


### PR DESCRIPTION
Closes #78 

I have added an example, it's a bit different from my demo exposed in #78 but I think it shows better the use-case. Feel free to comment how improve the use-case :smile:

I can't test if my tests works because I think that `yarn test:app` is broken on my side and I don't know why :sweat_smile:
![image](https://user-images.githubusercontent.com/7110786/77649730-9ed1fd80-6f6a-11ea-9cfd-bbb4bb182baf.png)

