### PR TITLE
feat: add imports option to configure

### DIFF
--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   preset: 'jest-preset-angular',
   rootDir: '../',
-  setupFilesAfterEnv: ['<rootDir>/test.ts'],
   transformIgnorePatterns: ['node_modules/(?!@ngrx)'],
+
   snapshotSerializers: [
     'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
     'jest-preset-angular/build/AngularSnapshotSerializer.js',

--- a/projects/jest.lib.config.js
+++ b/projects/jest.lib.config.js
@@ -3,4 +3,9 @@ const baseConfig = require('../jest.base.config');
 module.exports = {
   ...baseConfig,
   roots: ['<rootDir>/projects'],
+  setupFilesAfterEnv: ['<rootDir>/projects/setupJest.ts'],
+  displayName: {
+    name: 'LIB',
+    color: 'magenta',
+  },
 };

--- a/projects/setupJest.ts
+++ b/projects/setupJest.ts
@@ -1,0 +1,2 @@
+import 'jest-preset-angular';
+import '@testing-library/jest-dom';

--- a/projects/testing-library/src/lib/config.ts
+++ b/projects/testing-library/src/lib/config.ts
@@ -1,0 +1,24 @@
+import { Config } from './models';
+
+let config: Config = {
+  defaultImports: [],
+  dom: {},
+};
+
+export function configure(newConfig: Partial<Config> | ((config: Partial<Config>) => Partial<Config>)) {
+  if (typeof newConfig === 'function') {
+    // Pass the existing config out to the provided function
+    // and accept a delta in return
+    newConfig = newConfig(config);
+  }
+
+  // Merge the incoming config delta
+  config = {
+    ...config,
+    ...newConfig,
+  };
+}
+
+export function getConfig() {
+  return config;
+}

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -313,4 +313,4 @@ export interface RenderDirectiveOptions<DirectiveType, WrapperType, Q extends Qu
   componentProperties?: Partial<any>;
 }
 
-export type Config = dtlConfig & { defaultImports: any[] };
+export type Config = { defaultImports: any[]; dom: Partial<dtlConfig> };

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -313,4 +313,7 @@ export interface RenderDirectiveOptions<DirectiveType, WrapperType, Q extends Qu
   componentProperties?: Partial<any>;
 }
 
-export type Config = { defaultImports: any[]; dom: Partial<dtlConfig> };
+export interface Config {
+  defaultImports: any[];
+  dom: Partial<dtlConfig>;
+}

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -1,7 +1,15 @@
 import { Type, DebugElement } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { Routes } from '@angular/router';
-import { BoundFunction, FireObject, Queries, queries, waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
+import {
+  BoundFunction,
+  FireObject,
+  Queries,
+  queries,
+  waitFor,
+  waitForElementToBeRemoved,
+  Config as dtlConfig,
+} from '@testing-library/dom';
 import { UserEvents } from './user-events';
 import { OptionsReceived } from 'pretty-format';
 
@@ -304,3 +312,5 @@ export interface RenderDirectiveOptions<DirectiveType, WrapperType, Q extends Qu
   wrapper?: Type<WrapperType>;
   componentProperties?: Partial<any>;
 }
+
+export type Config = dtlConfig & { defaultImports: any[] };

--- a/projects/testing-library/src/public_api.ts
+++ b/projects/testing-library/src/public_api.ts
@@ -4,4 +4,5 @@
 
 export * from './lib/models';
 export * from './lib/user-events';
+export * from './lib/config';
 export * from './lib/testing-library';

--- a/projects/testing-library/tests/config.spec.ts
+++ b/projects/testing-library/tests/config.spec.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { render, configure } from '../src/public_api';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+
+@Component({
+  selector: 'app-fixture',
+  template: `
+    <form [formGroup]="form" name="form">
+      <div>
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" formControlName="name" />
+      </div>
+    </form>
+  `,
+})
+class FormsComponent {
+  form = this.formBuilder.group({
+    name: [''],
+  });
+
+  constructor(private formBuilder: FormBuilder) {}
+}
+
+let originalConfig;
+beforeEach(() => {
+  // Grab the existing configuration so we can restore
+  // it at the end of the test
+  configure((existingConfig) => {
+    originalConfig = existingConfig;
+    // Don't change the existing config
+    return {};
+  });
+});
+
+afterEach(() => {
+  configure(originalConfig);
+});
+
+beforeEach(() => {
+  configure({
+    defaultImports: [ReactiveFormsModule],
+  });
+});
+
+test('adds default imports to the testbed', async () => {
+  await render(FormsComponent);
+
+  const reactive = TestBed.inject(ReactiveFormsModule);
+  expect(reactive).not.toBeNull();
+});

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -1,8 +1,7 @@
 import { Component, NgModule, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { NoopAnimationsModule, BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TestBed } from '@angular/core/testing';
-import { render, configure } from '../src/public_api';
-import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { render } from '../src/public_api';
 
 @Component({
   selector: 'fixture',
@@ -115,39 +114,5 @@ describe('Angular component life-cycle hooks', () => {
     expect(nameChanged).toBeCalledWith('Sarah', true);
     // expect `nameChanged` to be called before `nameInitialized`
     expect(nameChanged.mock.invocationCallOrder[0]).toBeLessThan(nameInitialized.mock.invocationCallOrder[0]);
-  });
-});
-
-describe('configure: default imports', () => {
-  @Component({
-    selector: 'app-fixture',
-    template: `
-      <form [formGroup]="form" name="form">
-        <div>
-          <label for="name">Name</label>
-          <input type="text" id="name" name="name" formControlName="name" />
-        </div>
-      </form>
-    `,
-  })
-  class FormsComponent {
-    form = this.formBuilder.group({
-      name: [''],
-    });
-
-    constructor(private formBuilder: FormBuilder) {}
-  }
-
-  beforeEach(() => {
-    configure({
-      defaultImports: [ReactiveFormsModule],
-    });
-  });
-
-  test('adds default imports to the testbed', async () => {
-    await render(FormsComponent);
-
-    const reactive = TestBed.inject(ReactiveFormsModule);
-    expect(reactive).not.toBeNull();
   });
 });

--- a/src/app/examples/03-forms.spec.ts
+++ b/src/app/examples/03-forms.spec.ts
@@ -1,13 +1,10 @@
-import { ReactiveFormsModule } from '@angular/forms';
 import { render, screen, fireEvent } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
 import { FormsComponent } from './03-forms';
 
 test('is possible to fill in a form and verify error messages (with the help of jest-dom https://testing-library.com/docs/ecosystem-jest-dom)', async () => {
-  await render(FormsComponent, {
-    imports: [ReactiveFormsModule],
-  });
+  await render(FormsComponent);
 
   const nameControl = screen.getByRole('textbox', { name: /name/i });
   const scoreControl = screen.getByRole('spinbutton', { name: /score/i });

--- a/src/app/examples/03-forms.ts
+++ b/src/app/examples/03-forms.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormBuilder, Validators, ReactiveFormsModule, ValidationErrors } from '@angular/forms';
+import { FormBuilder, Validators, ValidationErrors } from '@angular/forms';
 
 @Component({
   selector: 'app-fixture',

--- a/src/app/examples/04-forms-with-material.spec.ts
+++ b/src/app/examples/04-forms-with-material.spec.ts
@@ -1,4 +1,3 @@
-import { ReactiveFormsModule } from '@angular/forms';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
@@ -7,7 +6,7 @@ import { MaterialFormsComponent } from './04-forms-with-material';
 
 test('is possible to fill in a form and verify error messages (with the help of jest-dom https://testing-library.com/docs/ecosystem-jest-dom)', async () => {
   const { fixture } = await render(MaterialFormsComponent, {
-    imports: [ReactiveFormsModule, MaterialModule],
+    imports: [MaterialModule],
   });
 
   const nameControl = screen.getByLabelText(/name/i);

--- a/src/app/examples/04-forms-with-material.ts
+++ b/src/app/examples/04-forms-with-material.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormBuilder, Validators, ReactiveFormsModule, ValidationErrors } from '@angular/forms';
+import { FormBuilder, Validators, ValidationErrors } from '@angular/forms';
 
 @Component({
   selector: 'app-fixture',

--- a/src/jest.app.config.js
+++ b/src/jest.app.config.js
@@ -2,6 +2,12 @@ const baseConfig = require('../jest.base.config');
 
 module.exports = {
   ...baseConfig,
+
   roots: ['<rootDir>/src'],
   modulePaths: ['<rootDir>/dist'],
+  setupFilesAfterEnv: ['<rootDir>/src/setupJest.ts'],
+  displayName: {
+    name: 'EXAMPLE',
+    color: 'blue',
+  },
 };

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -3,8 +3,6 @@ import '@testing-library/jest-dom';
 import { configure } from '@testing-library/angular';
 import { ReactiveFormsModule } from '@angular/forms';
 
-beforeEach(() => {
-  configure({
-    defaultImports: [ReactiveFormsModule],
-  });
+configure({
+  defaultImports: [ReactiveFormsModule],
 });

--- a/test.ts
+++ b/test.ts
@@ -1,2 +1,10 @@
 import 'jest-preset-angular';
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/angular';
+import { ReactiveFormsModule } from '@angular/forms';
+
+beforeEach(() => {
+  configure({
+    defaultImports: [ReactiveFormsModule],
+  });
+});


### PR DESCRIPTION
Allows the `configure` method to be used to add frequently used modules.
This can be helpful for example setting the forms module at a global level instead of importing the module in every test.

```ts
beforeEach(() => {
  configure({
    defaultImports: [ReactiveFormsModule],
  });
});
```