### PR TITLE
Update docs and jest config

### DIFF
--- a/apps/example-app/app/examples/README.md
+++ b/apps/example-app/app/examples/README.md
@@ -4,7 +4,7 @@ Follow these three steps to run the example tests:
 
 - clone or download the repository
 - move into the repository and install the needed dependencies with `npm install`
-- use the command `npm run test:app` from within the root of this repository to run the tests
+- use the command `npx nx test example-app` from within the root of this repository to run the tests
 
 The tests in this repository are written with [Jest](https://jestjs.io/), but you can use the test runner of your choice.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,12 +14,14 @@ module.exports = {
   ],
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/tsconfig.spec.json',
+      tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
-      astTransformers: [
-        'jest-preset-angular/build/InlineFilesTransformer',
-        'jest-preset-angular/build/StripStylesTransformer',
-      ],
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ]
+      },
     },
   },
 };


### PR DESCRIPTION
Fixes deprecation warnings:

```
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead

ts-jest[config] (WARN) The configuration for astTransformers as string[] is deprecated and will be removed in ts-jest 27. Please define your custom AST transformers in a form of an object. More information you can check online documentation https://kulshekhar.github.io/ts-jest/user/config/astTransformers
```