### PR TITLE
feat: destroy fixture in cleanup (#240)

### DIFF
--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -363,6 +363,8 @@ function cleanup() {
 }
 
 function cleanupAtFixture(fixture) {
+  fixture.destroy();
+
   if (!fixture.nativeElement.getAttribute('ng-version') && fixture.nativeElement.parentNode === document.body) {
     document.body.removeChild(fixture.nativeElement);
   }


### PR DESCRIPTION
This change destroys the fixture (and in turn the components) after each test. This will prevent weird errors and free the components memory.

Fixes #240