### PR TITLE
chore: set protocol for npm to `https`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/
 package-lock=false


### PR DESCRIPTION
Following https://github.com/testing-library/react-testing-library/pull/975

**Why**:
```
npm notice Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect.
```

**Checklist**:
- [x] Ready to be merged
