### PR TITLE
feat: add rerender method

### DIFF
--- a/apps/example-app-karma/src/app/issues/issue-222.spec.ts
+++ b/apps/example-app-karma/src/app/issues/issue-222.spec.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/angular';
 
-it('https://github.com/testing-library/angular-testing-library/issues/222', async () => {
+it('https://github.com/testing-library/angular-testing-library/issues/222 with rerender', async () => {
   const { rerender } = await render(`<div>Hello {{ name}}</div>`, {
     componentProperties: {
       name: 'Sarah',
@@ -8,7 +8,21 @@ it('https://github.com/testing-library/angular-testing-library/issues/222', asyn
   });
 
   expect(screen.getByText('Hello Sarah')).toBeTruthy();
-  rerender({ name: 'Mark' });
+
+  await rerender({ name: 'Mark' });
+
+  expect(screen.getByText('Hello Mark')).toBeTruthy();
+});
+
+it('https://github.com/testing-library/angular-testing-library/issues/222 with change', async () => {
+  const { change } = await render(`<div>Hello {{ name}}</div>`, {
+    componentProperties: {
+      name: 'Sarah',
+    },
+  });
+
+  expect(screen.getByText('Hello Sarah')).toBeTruthy();
+  await change({ name: 'Mark' });
 
   expect(screen.getByText('Hello Mark')).toBeTruthy();
 });

--- a/apps/example-app/src/app/examples/16-input-getter-setter.spec.ts
+++ b/apps/example-app/src/app/examples/16-input-getter-setter.spec.ts
@@ -10,16 +10,29 @@ test('should run logic in the input setter and getter', async () => {
   expect(getterValueControl).toHaveTextContent('I am value from getter Angular');
 });
 
-test('should run logic in the input setter and getter while re-rendering', async () => {
-  const { rerender } = await render(InputGetterSetter, { componentProperties: { value: 'Angular' } });
+test('should run logic in the input setter and getter while changing', async () => {
+  const { change } = await render(InputGetterSetter, { componentProperties: { value: 'Angular' } });
   const valueControl = screen.getByTestId('value');
   const getterValueControl = screen.getByTestId('value-getter');
 
   expect(valueControl).toHaveTextContent('I am value from setter Angular');
   expect(getterValueControl).toHaveTextContent('I am value from getter Angular');
 
-  await rerender({ value: 'React' });
+  await change({ value: 'React' });
 
   expect(valueControl).toHaveTextContent('I am value from setter React');
   expect(getterValueControl).toHaveTextContent('I am value from getter React');
+});
+
+test('should run logic in the input setter and getter while re-rendering', async () => {
+  const { rerender } = await render(InputGetterSetter, { componentProperties: { value: 'Angular' } });
+
+  expect(screen.getByTestId('value')).toHaveTextContent('I am value from setter Angular');
+  expect(screen.getByTestId('value-getter')).toHaveTextContent('I am value from getter Angular');
+
+  await rerender({ value: 'React' });
+
+  // note we have to re-query because the elements are not the same anymore
+  expect(screen.getByTestId('value')).toHaveTextContent('I am value from setter React');
+  expect(screen.getByTestId('value-getter')).toHaveTextContent('I am value from getter React');
 });

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -56,7 +56,13 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType> extend
    * @description
    * Re-render the same component with different props.
    */
-  rerender: (componentProperties: Partial<ComponentType>) => void;
+  rerender: (rerenderedProperties: Partial<ComponentType>) => void;
+
+  /**
+   * @description
+   * Re-render the component while invoking ngOnChanges.
+   */
+  change: (changedProperties: Partial<ComponentType>) => void;
 }
 
 export interface RenderComponentOptions<ComponentType, Q extends Queries = typeof queries> {

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -54,13 +54,14 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType> extend
   navigate: (elementOrPath: Element | string, basePath?: string) => Promise<boolean>;
   /**
    * @description
-   * Re-render the same component with different props.
+   * Re-render the same component with different properties.
+   * This creates a new instance of the component.
    */
   rerender: (rerenderedProperties: Partial<ComponentType>) => void;
 
   /**
    * @description
-   * Re-render the component while invoking ngOnChanges.
+   * Keeps the current fixture intact and invokes ngOnChanges with the updated properties.
    */
   change: (changedProperties: Partial<ComponentType>) => void;
 }

--- a/projects/testing-library/tests/change.spec.ts
+++ b/projects/testing-library/tests/change.spec.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { render, screen } from '../src/public_api';
+
+@Component({
+  selector: 'atl-fixture',
+  template: ` {{ firstName }} {{ lastName }} `,
+})
+class FixtureComponent {
+  @Input() firstName = 'Sarah';
+  @Input() lastName;
+}
+
+test('changes the component with updated props', async () => {
+  const { change } = await render(FixtureComponent);
+  expect(screen.getByText('Sarah')).toBeInTheDocument();
+
+  const firstName = 'Mark';
+  change({ firstName });
+
+  expect(screen.getByText(firstName)).toBeInTheDocument();
+});
+
+test('changes the component with updated props while keeping other props untouched', async () => {
+  const firstName = 'Mark';
+  const lastName = 'Peeters';
+  const { change } = await render(FixtureComponent, {
+    componentProperties: {
+      firstName,
+      lastName,
+    },
+  });
+
+  expect(screen.getByText(`${firstName} ${lastName}`)).toBeInTheDocument();
+
+  const firstName2 = 'Chris';
+  change({ firstName: firstName2 });
+
+  expect(screen.getByText(`${firstName2} ${lastName}`)).toBeInTheDocument();
+});
+
+@Component({
+  selector: 'atl-fixture',
+  template: ` {{ name }} `,
+})
+class FixtureWithNgOnChangesComponent implements OnChanges {
+  @Input() name = 'Sarah';
+  @Input() nameChanged: (name: string, isFirstChange: boolean) => void;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.name && this.nameChanged) {
+      this.nameChanged(changes.name.currentValue, changes.name.isFirstChange());
+    }
+  }
+}
+
+test('will call ngOnChanges on change', async () => {
+  const nameChanged = jest.fn();
+  const componentProperties = { nameChanged };
+  const { change } = await render(FixtureWithNgOnChangesComponent, { componentProperties });
+  expect(screen.getByText('Sarah')).toBeInTheDocument();
+
+  const name = 'Mark';
+  change({ name });
+
+  expect(screen.getByText(name)).toBeInTheDocument();
+  expect(nameChanged).toHaveBeenCalledWith(name, false);
+});
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'atl-fixture',
+  template: ` <div data-testid="number" [class.active]="activeField === 'number'">Number</div> `,
+})
+class FixtureWithOnPushComponent {
+  @Input() activeField: string;
+}
+
+test('update properties on change', async () => {
+  const { change } = await render(FixtureWithOnPushComponent);
+  const numberHtmlElementRef = screen.queryByTestId('number');
+
+  expect(numberHtmlElementRef).not.toHaveClass('active');
+  change({ activeField: 'number' });
+  expect(numberHtmlElementRef).toHaveClass('active');
+});


### PR DESCRIPTION
Closes #252

BREAKING CHANGE:

rerender has been renamed to change
change keeps the current fixture intact and invokes ngOnChanges

the new rerender method destroys the current component and creates a new instance
with the updated properties

BEFORE:

const { rerender } = render(...)
rerender({...})

AFTER:

const { change } = render(...)
change({...})