### PR TITLE
feat: remove RenderDirectiveOptions

### DIFF
--- a/apps/example-app/src/app/examples/02-input-output.spec.ts
+++ b/apps/example-app/src/app/examples/02-input-output.spec.ts
@@ -33,8 +33,8 @@ test('is possible to set input and listen for output', async () => {
 test('is possible to set input and listen for output with the template syntax', async () => {
   const sendSpy = jest.fn();
 
-  await render(InputOutputComponent, {
-    template: '<app-fixture [value]="47" (sendValue)="sendValue($event)" (clicked)="clicked()"></app-fixture>',
+  await render('<app-fixture [value]="47" (sendValue)="sendValue($event)" (clicked)="clicked()"></app-fixture>', {
+    declarations: [InputOutputComponent],
     componentProperties: {
       sendValue: sendSpy,
     },

--- a/apps/example-app/src/app/examples/11-ng-content.spec.ts
+++ b/apps/example-app/src/app/examples/11-ng-content.spec.ts
@@ -7,8 +7,8 @@ test('it is possible to test ng-content without selector', async () => {
   const projection = 'it should be showed into a p element!';
 
   TestBed.overrideComponent(CellComponent, { set: { selector: 'cell' } });
-  await render(CellComponent, {
-    template: `<cell data-testid="one-cell-with-ng-content">${projection}</cell>`,
+  await render(`<cell data-testid="one-cell-with-ng-content">${projection}</cell>`, {
+    declarations: [CellComponent],
   });
 
   expect(screen.getByText(projection)).toBeInTheDocument();

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -256,43 +256,6 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   removeAngularAttributes?: boolean;
 }
 
-/**
- * @deprecated Use `render(template, { declarations: [SomeDirective] })` instead.
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export interface RenderDirectiveOptions<WrapperType, Properties extends object = {}, Q extends Queries = typeof queries>
-  extends RenderComponentOptions<Properties, Q> {
-  /**
-   * @description
-   * The template to render the directive.
-   * This template will override the template from the WrapperComponent.
-   *
-   * @example
-   * const component = await render(SpoilerDirective, {
-   *  template: `<div spoiler message='SPOILER'></div>`
-   * })
-   *
-   * @deprecated Use `render(template, { declarations: [SomeDirective] })` instead.
-   */
-  template: string;
-  /**
-   * @description
-   * An Angular component to wrap the component in.
-   * The template will be overridden with the `template` option.
-   *
-   * @default
-   * `WrapperComponent`, an empty component that strips the `ng-version` attribute
-   *
-   * @example
-   * const component = await render(SpoilerDirective, {
-   *  template: `<div spoiler message='SPOILER'></div>`
-   *  wrapper: CustomWrapperComponent
-   * })
-   */
-  wrapper?: Type<WrapperType>;
-  componentProperties?: Partial<WrapperType & Properties>;
-}
-
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface RenderTemplateOptions<WrapperType, Properties extends object = {}, Q extends Queries = typeof queries>
   extends RenderComponentOptions<Properties, Q> {

--- a/projects/testing-library/tests/render-template.spec.ts
+++ b/projects/testing-library/tests/render-template.spec.ts
@@ -62,15 +62,6 @@ test('the component renders', async () => {
   expect(screen.getByText('Hello Angular!')).toBeInTheDocument();
 });
 
-test('the directive renders (compatibility with the deprecated signature)', async () => {
-  const view = await render(OnOffDirective, {
-    template: '<div onOff></div>',
-  });
-
-  // eslint-disable-next-line testing-library/no-container
-  expect(view.container.querySelector('[onoff]')).toBeInTheDocument();
-});
-
 test('uses the default props', async () => {
   await render('<div onOff></div>', {
     declarations: [OnOffDirective],


### PR DESCRIPTION
BREAKING CHANGE:

The template property is removed from the render options.
Instead, you can pass it as the first argument of `render.

BEFORE:

```ts
await render(InputOutputComponent, {
  // 👇 this is deprecated
  template: '<app-fixture [value]="47" (sendValue)="sendValue($event)" (clicked)="clicked()"></app-fixture>',
  componentProperties: {
    sendValue: sendSpy,
  },
});
```

AFTER:

```ts
//           👇 Move the template in the first argument
await render('<app-fixture [value]="47" (sendValue)="sendValue($event)" (clicked)="clicked()"></app-fixture>', {
//               👇 Add the component to declarations
  declarations: [InputOutputComponent],
  componentProperties: {
    sendValue: sendSpy,
  },
});
```