### PR TITLE
test: enhance example to verify pre-set form values on a Material sel…

### DIFF
--- a/apps/example-app/src/app/examples/04-forms-with-material.spec.ts
+++ b/apps/example-app/src/app/examples/04-forms-with-material.spec.ts
@@ -3,6 +3,9 @@ import userEvent from '@testing-library/user-event';
 
 import { MaterialModule } from '../material.module';
 import { MaterialFormsComponent } from './04-forms-with-material';
+import { FormBuilder, Validators } from "@angular/forms";
+import { By } from "@angular/platform-browser";
+
 
 test('is possible to fill in a form and verify error messages (with the help of jest-dom https://testing-library.com/docs/ecosystem-jest-dom)', async () => {
   const { fixture } = await render(MaterialFormsComponent, {
@@ -37,12 +40,46 @@ test('is possible to fill in a form and verify error messages (with the help of 
 
   expect(nameControl).toHaveValue('Tim');
   expect(scoreControl).toHaveValue(7);
+  expect(colorControl).toHaveTextContent('Green');
 
   const form = screen.getByRole('form');
   expect(form).toHaveFormValues({
     name: 'Tim',
     score: 7,
   });
-
   expect((fixture.componentInstance as MaterialFormsComponent).form?.get('color')?.value).toBe('G');
+});
+
+test('is should show pre-set form values', async () => {
+  const formBuilder = new FormBuilder();
+
+  const { fixture, detectChanges } = await render(MaterialFormsComponent, {
+    imports: [MaterialModule],
+    componentProperties: {
+      form: formBuilder.group({
+        name: ['Max', Validators.required],
+        score: [4, [Validators.min(1), Validators.max(10)]],
+        color: ['B', Validators.required],
+      }),
+    },
+  });
+
+  const nameControl = screen.getByLabelText(/name/i);
+  const scoreControl = screen.getByRole('spinbutton', { name: /score/i });
+  const colorControl = screen.getByRole('combobox', { name: /color/i });
+
+  expect(nameControl).toHaveValue('Max');
+  expect(scoreControl).toHaveValue(4);
+
+  fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
+  detectChanges();
+  expect(colorControl).toHaveTextContent('Blue');
+
+  const form = screen.getByRole('form');
+  expect(form).toHaveFormValues({
+    name: 'Max',
+    score: 4,
+  });
+
+  expect((fixture.componentInstance as MaterialFormsComponent).form?.get('color')?.value).toBe('B');
 });

--- a/apps/example-app/src/app/examples/04-forms-with-material.spec.ts
+++ b/apps/example-app/src/app/examples/04-forms-with-material.spec.ts
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event';
 
 import { MaterialModule } from '../material.module';
 import { MaterialFormsComponent } from './04-forms-with-material';
-import { FormBuilder, Validators } from "@angular/forms";
-import { By } from "@angular/platform-browser";
 
 
 test('is possible to fill in a form and verify error messages (with the help of jest-dom https://testing-library.com/docs/ecosystem-jest-dom)', async () => {
@@ -51,18 +49,16 @@ test('is possible to fill in a form and verify error messages (with the help of 
 });
 
 test('is should show pre-set form values', async () => {
-  const formBuilder = new FormBuilder();
-
   const { fixture, detectChanges } = await render(MaterialFormsComponent, {
     imports: [MaterialModule],
-    componentProperties: {
-      form: formBuilder.group({
-        name: ['Max', Validators.required],
-        score: [4, [Validators.min(1), Validators.max(10)]],
-        color: ['B', Validators.required],
-      }),
-    },
   });
+
+  fixture.componentInstance.form.setValue({
+    name: 'Max',
+    score: 4,
+    color: 'B'
+  })
+  detectChanges();
 
   const nameControl = screen.getByLabelText(/name/i);
   const scoreControl = screen.getByRole('spinbutton', { name: /score/i });
@@ -70,9 +66,6 @@ test('is should show pre-set form values', async () => {
 
   expect(nameControl).toHaveValue('Max');
   expect(scoreControl).toHaveValue(4);
-
-  fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement.click();
-  detectChanges();
   expect(colorControl).toHaveTextContent('Blue');
 
   const form = screen.getByRole('form');
@@ -80,6 +73,5 @@ test('is should show pre-set form values', async () => {
     name: 'Max',
     score: 4,
   });
-
   expect((fixture.componentInstance as MaterialFormsComponent).form?.get('color')?.value).toBe('B');
 });

--- a/apps/example-app/src/app/examples/04-forms-with-material.spec.ts
+++ b/apps/example-app/src/app/examples/04-forms-with-material.spec.ts
@@ -48,7 +48,7 @@ test('is possible to fill in a form and verify error messages (with the help of 
   expect((fixture.componentInstance as MaterialFormsComponent).form?.get('color')?.value).toBe('G');
 });
 
-test('is should show pre-set form values', async () => {
+test('set and show pre-set form values', async () => {
   const { fixture, detectChanges } = await render(MaterialFormsComponent, {
     imports: [MaterialModule],
   });

--- a/apps/example-app/src/app/examples/04-forms-with-material.ts
+++ b/apps/example-app/src/app/examples/04-forms-with-material.ts
@@ -24,6 +24,9 @@ import { FormBuilder, Validators } from '@angular/forms';
 
       <mat-form-field>
         <mat-select placeholder="Color" name="color" formControlName="color">
+          <mat-select-trigger>
+            {{ colorControlDisplayValue }}
+          </mat-select-trigger>
           <mat-option value="">---</mat-option>
           <mat-option *ngFor="let color of colors" [value]="color.id">{{ color.value }}</mat-option>
         </mat-select>
@@ -60,10 +63,15 @@ export class MaterialFormsComponent {
   form = this.formBuilder.group({
     name: ['', Validators.required],
     score: [0, [Validators.min(1), Validators.max(10)]],
-    color: ['', Validators.required],
+    color: [null, Validators.required],
   });
 
   constructor(private formBuilder: FormBuilder) {}
+
+  get colorControlDisplayValue(): string | undefined {
+    const selectedId = this.form.get('color')?.value;
+    return this.colors.filter(color => color.id === selectedId)[0]?.value;
+  }
 
   get formErrors() {
     return Object.keys(this.form.controls)


### PR DESCRIPTION
This PR enhances the example test for Angular Material Forms.
It shows how to read and verify any pre-set form  and display values on a select box.

Based on https://github.com/testing-library/angular-testing-library/issues/275