### PR TITLE
feat: support componentImports option for standalone components

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -188,6 +188,23 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   componentProviders?: any[];
   /**
    * @description
+   * A collection of imports to override a standalone component's imports with.
+   *
+   * @default
+   * undefined
+   *
+   * @example
+   * const component = await render(AppComponent, {
+   *   ɵcomponentImports: [
+   *     MockChildComponent
+   *   ]
+   * })
+   *
+   * @experimental
+   */
+  ɵcomponentImports?: (Type<any> | any[])[];
+  /**
+   * @description
    * Queries to bind. Overrides the default set from DOM Testing Library unless merged.
    *
    * @default

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -19,7 +19,7 @@ import { render, fireEvent, screen } from '../src/public_api';
     <button>button</button>
   `,
 })
-class FixtureComponent {}
+class FixtureComponent { }
 
 test('creates queries and events', async () => {
   const view = await render(FixtureComponent);
@@ -48,6 +48,51 @@ describe('standalone', () => {
   });
 });
 
+describe('standalone with child', () => {
+  @Component({
+    selector: 'child-fixture',
+    template: `<span>A child fixture</span>`,
+    standalone: true,
+  })
+  class ChildFixture { }
+
+  @Component({
+    selector: 'child-fixture',
+    template: `<span>A mock child fixture</span>`,
+    standalone: true,
+  })
+  class MockChildFixture { }
+
+  @Component({
+    selector: 'parent-fixture',
+    template: `<h1>Parent fixture</h1>
+      <div><child-fixture></child-fixture></div> `,
+    standalone: true,
+    imports: [ChildFixture],
+  })
+  class ParentFixture { }
+
+  it('renders the standalone component with child', async () => {
+    await render(ParentFixture);
+    expect(screen.getByText('Parent fixture'));
+    expect(screen.getByText('A child fixture'));
+  });
+
+  it('renders the standalone component with child', async () => {
+    await render(ParentFixture, { ɵcomponentImports: [MockChildFixture] });
+    expect(screen.getByText('Parent fixture'));
+    expect(screen.getByText('A mock child fixture'));
+  });
+
+  it('rejects render of template with componentImports set', () => {
+    const result = render(`<div><parent-fixture></parent-fixture></div>`, {
+      imports: [ParentFixture],
+      ɵcomponentImports: [MockChildFixture],
+    });
+    return expect(result).rejects.toMatchObject({ message: /Error while rendering/ });
+  });
+});
+
 describe('removeAngularAttributes', () => {
   it('should remove angular attribute', async () => {
     await render(FixtureComponent, {
@@ -72,7 +117,7 @@ describe('animationModule', () => {
   @NgModule({
     declarations: [FixtureComponent],
   })
-  class FixtureModule {}
+  class FixtureModule { }
   describe('excludeComponentDeclaration', () => {
     it('does not throw if component is declared in an imported module', async () => {
       await render(FixtureComponent, {


### PR DESCRIPTION
Closes #306 

This is a first stab at adding the ability to override the `imports` metadata field for standalone components.

This PR adds the `componentImports` field to the `render` function options. These imports are used to override the existing imports on a standalone component. The reasons for completely overriding imports are:

- It's the most simple option API-wise. It's possible you could be more granular and allow the user to specify specific imports to override but this is likely overkill.
- This is more similar to the 'blank slate' model of imports that all Angular component tests used prior to standalone components where you would need to specify all your dependencies in `TestBed.configureTestModule`.

As implemented, this only works for the `render(FooComponent)` style rendering and throws an error if  `componentImports` option is passed when the subject-under-test is template or non-standalone component.