### PR TITLE
Fix 'rerender' type to Promise<void>

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -57,7 +57,7 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType> extend
    * Re-render the same component with different properties.
    * This creates a new instance of the component.
    */
-  rerender: (rerenderedProperties: Partial<ComponentType>) => void;
+  rerender: (rerenderedProperties: Partial<ComponentType>) => Promise<void>;
 
   /**
    * @description


### PR DESCRIPTION
Hello,

I noticed that since this [change](https://github.com/mateusduraes/angular-testing-library/commit/cd17373272d517057c4650d2ccc13e61b07c27a6#diff-8e35d38d4ce658063a1f7522f82a938a8b99a52223927129ad8ddd28df541506R116) the `rerender` function became an async function, meaning that now it will return a `Promise`.

However, the return type of the `rerender` function wasn't updated from `void` to `Promise<void>` so I decided to open this PR.