### PR TITLE
fix: don't fire router events on render

### DIFF
--- a/projects/testing-library/tests/issues/issue-318.spec.ts
+++ b/projects/testing-library/tests/issues/issue-318.spec.ts
@@ -1,0 +1,43 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Subject, takeUntil} from 'rxjs';
+import {render} from "@testing-library/angular";
+
+@Component({
+  selector: 'atl-app-fixture',
+  template: '',
+})
+class FixtureComponent implements OnInit, OnDestroy {
+  unsubscribe$ = new Subject<void>();
+
+  constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    this.router.events.pipe(takeUntil(this.unsubscribe$)).subscribe((evt) => {
+      this.eventReceived(evt)
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  eventReceived(evt: any) {
+    console.log(evt);
+  }
+}
+
+
+test('it does not invoke router events on init', async () => {
+  const eventReceived = jest.fn();
+  await render(FixtureComponent, {
+    imports: [RouterTestingModule],
+    componentProperties: {
+      eventReceived
+    }
+  });
+  expect(eventReceived).not.toHaveBeenCalled();
+});
+


### PR DESCRIPTION
This is done to represent a more real Angular running environment

Closes #318