### PR TITLE
chore: update peer dependencies

### DIFF
--- a/projects/testing-library/package.json
+++ b/projects/testing-library/package.json
@@ -29,11 +29,11 @@
     "migrations": "./schematics/migrations/migration.json"
   },
   "peerDependencies": {
-    "@angular/common": ">= 14.0.0",
-    "@angular/platform-browser": ">= 14.0.0",
-    "@angular/router": ">= 14.0.0",
-    "@angular/core": ">= 14.0.0",
-    "rxjs": ">= 7.4.0"
+    "@angular/common": "^4.1.0",
+    "@angular/platform-browser": "^14.1.0",
+    "@angular/router": "^14.1.0",
+    "@angular/core": "^14.1.0",
+    "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
     "@testing-library/dom": "^8.0.0",


### PR DESCRIPTION
BREAKING CHANGE:

BEFORE:

The minimum version of Angular is v14.0.0

AFTER:

The minimum version of Angular is v14.1.0