### PR TITLE
Added childComponentOverrides property to override nested child providers

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -188,6 +188,26 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   componentProviders?: any[];
   /**
    * @description
+   * Collection of child component specified providers to override with
+   *
+   * @default
+   * []
+   *
+   * @example
+   * await render(AppComponent, {
+   *  childComponentOverrides: [
+   *    {
+   *      component: ChildOfAppComponent,
+   *      providers: [{ provide: MyService, useValue: { hello: 'world' } }]
+   *    }
+   *  ]
+   * })
+   *
+   * @experimental
+   */
+  childComponentOverrides?: ComponentOverride<any>[];
+  /**
+   * @description
    * A collection of imports to override a standalone component's imports with.
    *
    * @default
@@ -271,6 +291,11 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * })
    */
   removeAngularAttributes?: boolean;
+}
+
+export interface ComponentOverride<T> {
+  component: Type<T>;
+  providers: any[];
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -25,7 +25,7 @@ import {
   queries as dtlQueries,
 } from '@testing-library/dom';
 import type { Queries, BoundFunctions } from '@testing-library/dom';
-import { RenderComponentOptions, RenderTemplateOptions, RenderResult } from './models';
+import { RenderComponentOptions, RenderTemplateOptions, RenderResult, ComponentOverride } from './models';
 import { getConfig } from './config';
 
 const mountedFixtures = new Set<ComponentFixture<any>>();
@@ -55,6 +55,7 @@ export async function render<SutType, WrapperType = SutType>(
     wrapper = WrapperComponent as Type<WrapperType>,
     componentProperties = {},
     componentProviders = [],
+    childComponentOverrides = [],
     ɵcomponentImports: componentImports,
     excludeComponentDeclaration = false,
     routes = [],
@@ -85,6 +86,7 @@ export async function render<SutType, WrapperType = SutType>(
     schemas: [...schemas],
   });
   overrideComponentImports(sut, componentImports);
+  overrideChildComponentProviders(childComponentOverrides);
 
   await TestBed.compileComponents();
 
@@ -280,6 +282,12 @@ function overrideComponentImports<SutType>(sut: Type<SutType> | string, imports:
       );
     }
   }
+}
+
+function overrideChildComponentProviders(componentOverrides: ComponentOverride<any>[]) {
+  componentOverrides?.forEach(({ component, providers }) => {
+    TestBed.overrideComponent(component, { set: { providers } });
+  });
 }
 
 function hasOnChangesHook<SutType>(componentInstance: SutType): componentInstance is SutType & OnChanges {


### PR DESCRIPTION
This PR is to allow for specific child components to be overridden with providers as the introduction of standalone components and scoping services to specific components make it difficult to mock out services that might talk to external dependencies, especially when the component you are testing is higher up. Currently there is no way to mock component level providers for nested children which this tries to address.

Feel free to leave suggestions for improvements. I am hoping to at least get something out the door so that it is at least possible to override child providers.

I also added a test and an example in the description to show how this works
