### PR TITLE
feat: remove detectChanges in favor of detectChangesOnRender

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -91,22 +91,6 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   autoDetectChanges?: boolean;
   /**
    * @description
-   * Will call detectChanges when the component is compiled
-   *
-   * @default
-   * true
-   *
-   * @example
-   * const component = await render(AppComponent, {
-   *  detectChanges: false
-   * })
-   *
-   * @deprecated
-   * Use `detectChangesOnRender` instead
-   */
-  detectChanges?: boolean;
-  /**
-   * @description
    * Invokes `detectChanges` after the component is rendered
    *
    * @default

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -46,8 +46,7 @@ export async function render<SutType, WrapperType = SutType>(
 ): Promise<RenderResult<SutType>> {
   const { dom: domConfig, ...globalConfig } = getConfig();
   const {
-    detectChanges: detectChangesDeprecated = true,
-    detectChangesOnRender: detectChangesOnRenderInput,
+    detectChangesOnRender = true,
     autoDetectChanges = true,
     declarations = [],
     imports = [],
@@ -66,9 +65,6 @@ export async function render<SutType, WrapperType = SutType>(
     removeAngularAttributes = false,
     defaultImports = [],
   } = { ...globalConfig, ...renderOptions };
-
-  const detectChangesOnRender =
-    detectChangesOnRenderInput === undefined ? detectChangesDeprecated : detectChangesOnRenderInput;
 
   dtlConfigure(domConfig);
 


### PR DESCRIPTION
BREAKING CHANGE:
The config property detectChanges is renamed to detectChangesOnRender.

BEFORE:

```ts
const component = await render(AppComponent, {
  detectChanges: false
});
```

AFTER:

```ts
const component = await render(AppComponent, {
  detectChangesOnRender: false
});
```