### PR TITLE
feat: Added initialRoute parameter to avoid resolver issues with using a default route

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -330,6 +330,21 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
 
   /**
    * @description
+   * Specifies which route should be initially navigated to
+   *
+   * @example
+   * const component = await render(AppComponent, {
+   *  initialRoute: 'myroute',
+   *  routes: [
+   *    { path: '', component: HomeComponent },
+   *    { path: 'myroute', component: SecondaryComponent }
+   *  ]
+   * })
+   */
+  initialRoute?: string;
+
+  /**
+   * @description
    * Removes the Angular attributes (ng-version, and root-id) from the fixture.
    *
    * @default

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -64,6 +64,7 @@ export async function render<SutType, WrapperType = SutType>(
     routes = [],
     removeAngularAttributes = false,
     defaultImports = [],
+    initialRoute = '',
   } = { ...globalConfig, ...renderOptions };
 
   dtlConfigure({
@@ -106,6 +107,8 @@ export async function render<SutType, WrapperType = SutType>(
 
   const zone = safeInject(NgZone);
   const router = safeInject(Router);
+
+  if (initialRoute) await router.navigate([initialRoute]);
 
   if (typeof router?.initialNavigation === 'function') {
     if (zone) {

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -324,22 +324,21 @@ describe('initialRoute', () => {
   }
 
   it('allows initially rendering a specific route to avoid triggering a resolver for the default route', async () => {
-    const expectedRoute = 'correct-route';
+    const initialRoute = 'initial-route';
     const routes = [
-      { path: expectedRoute, component: FixtureComponent },
+      { path: initialRoute, component: FixtureComponent },
       { path: '**', resolve: { data: FixtureResolver }, component: SecondaryFixtureComponent },
     ];
 
     await render(RouterFixtureComponent, {
-      initialRoute: expectedRoute,
+      initialRoute,
       routes,
-      detectChangesOnRender: false,
       providers: [FixtureResolver],
     });
     const resolver = TestBed.inject(FixtureResolver);
 
     expect(resolver.isResolved).toBe(false);
     expect(screen.queryByText('Secondary Component')).not.toBeInTheDocument();
-    expect(await screen.findByText('button')).toBeInTheDocument();
+    expect(screen.getByText('button')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Added the ability to specify an initial route to render with. As someone who wanted to use my original routes in my tests, I found that even though I do initial navigation without detecting changes in my tests using navigate, I would still run into issues where my resolver would get triggered despite the fact I was switching before detecting changes.

This allows navigation to happen before the location listener is set up so that you may perform an initial route navigation without causing any resolvers/guards to run and additionally having to specify await navigate(...) in your tests