### PR TITLE
fix: add types for @testing-library/jasmine-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/jasmine": "4.0.3",
     "@types/jest": "28.1.8",
     "@types/node": "18.7.1",
+    "@types/testing-library__jasmine-dom": "^1.3.0",
     "@typescript-eslint/eslint-plugin": "5.36.1",
     "@typescript-eslint/parser": "5.36.1",
     "cpy-cli": "^3.1.1",


### PR DESCRIPTION
close #369

Cherry picking this commit into https://github.com/testing-library/angular-testing-library/pull/366 fixed its pipeline. I would like to merge this PR independently, to make clear this fix has nothing to do with it.