### PR TITLE
docs: use fine-grained overrides in examples

### DIFF
--- a/apps/example-app/src/app/examples/02-input-output.spec.ts
+++ b/apps/example-app/src/app/examples/02-input-output.spec.ts
@@ -6,8 +6,10 @@ test('is possible to set input and listen for output', async () => {
   const sendValue = jest.fn();
 
   await render(InputOutputComponent, {
-    componentProperties: {
+    componentInputs: {
       value: 47,
+    },
+    componentOutputs: {
       sendValue: {
         emit: sendValue,
       } as any,

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -221,9 +221,12 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * {}
    *
    * @example
+   * const sendValue = (value) => { ... }
    * const component = await render(AppComponent, {
    *  componentOutputs: {
-   *    send: (value) => { ... }
+   *    send: {
+   *      emit: sendValue
+   *    }
    *  }
    * })
    */

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -8,6 +8,8 @@ import {
   APP_INITIALIZER,
   ApplicationInitStatus,
   Injectable,
+  EventEmitter,
+  Output,
 } from '@angular/core';
 import { NoopAnimationsModule, BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TestBed } from '@angular/core/testing';
@@ -152,6 +154,28 @@ describe('removeAngularAttributes', () => {
 
     expect(document.querySelector('[ng-version]')).not.toBeNull();
     expect(document.querySelector('[id]')).not.toBeNull();
+  });
+});
+
+describe('componentOutputs', () => {
+  it('should set passed event emitter to the component', async () => {
+    @Component({ template: `` })
+    class TestFixtureComponent {
+      @Output() event = new EventEmitter<void>();
+      emitEvent() {
+        this.event.emit();
+      }
+    }
+
+    const mockEmitter = new EventEmitter<void>();
+    const spy = jest.spyOn(mockEmitter, 'emit');
+    const { fixture } = await render(TestFixtureComponent, {
+      componentOutputs: { event: mockEmitter },
+    });
+
+    fixture.componentInstance.emitEvent();
+
+    expect(spy).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Fixes #368