### PR TITLE
Accept query params in initialRoute property

### DIFF
--- a/projects/testing-library/tests/integrations/ng-mocks.spec.ts
+++ b/projects/testing-library/tests/integrations/ng-mocks.spec.ts
@@ -3,6 +3,7 @@ import { By } from '@angular/platform-browser';
 
 import { MockComponent } from 'ng-mocks';
 import { render } from '../../src/public_api';
+import { NgIf } from '@angular/common';
 
 test('sends the correct value to the child input', async () => {
   const utils = await render(TargetComponent, {
@@ -34,6 +35,7 @@ test('sends the correct value to the child input 2', async () => {
   selector: 'atl-child',
   template: 'child',
   standalone: true,
+  imports: [NgIf],
 })
 class ChildComponent {
   @ContentChild('something')

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -14,7 +14,9 @@ import {
 import { NoopAnimationsModule, BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TestBed } from '@angular/core/testing';
 import { render, fireEvent, screen } from '../src/public_api';
-import { Resolve, RouterModule } from '@angular/router';
+import { ActivatedRoute, Resolve, RouterModule } from '@angular/router';
+import { map } from 'rxjs';
+import { AsyncPipe, NgIf } from '@angular/common';
 
 @Component({
   selector: 'atl-fixture',
@@ -364,6 +366,30 @@ describe('initialRoute', () => {
     expect(resolver.isResolved).toBe(false);
     expect(screen.queryByText('Secondary Component')).not.toBeInTheDocument();
     expect(screen.getByText('button')).toBeInTheDocument();
+  });
+
+  it('allows initially rendering a specific route with query parameters', async () => {
+    @Component({
+      standalone: true,
+      selector: 'atl-query-param-fixture',
+      template: `<p>paramPresent$: {{ paramPresent$ | async }}</p>`,
+      imports: [NgIf, AsyncPipe],
+    })
+    class QueryParamFixtureComponent {
+      constructor(public route: ActivatedRoute) {}
+
+      paramPresent$ = this.route.queryParams.pipe(map((queryParams) => (queryParams?.param ? 'present' : 'missing')));
+    }
+
+    const initialRoute = 'initial-route?param=query';
+    const routes = [{ path: 'initial-route', component: QueryParamFixtureComponent }];
+
+    await render(RouterFixtureComponent, {
+      initialRoute,
+      routes,
+    });
+
+    expect(screen.getByText(/present/i)).toBeVisible();
   });
 });
 


### PR DESCRIPTION
The initalRoute property of the render() function will now accept query parameters. This way a component can be directly loaded in query parameters dependent state without a second navigation step.

The original navigate function is split into a external & internal function were the external function will also execute a detectChanges().