### PR TITLE
docs: update all contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ practices.</p>
 [![version][version-badge]][package] [![downloads][downloads-badge]][npmtrends]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/testing-library/angular-testing-library?color=ee8449&style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs] [![Code of Conduct][coc-badge]][coc]
 [![Discord][discord-badge]][discord]
 


### PR DESCRIPTION
This updates the all contributors badge url to the updated format, same as this change: https://github.com/testing-library/testing-library-docs/pull/1398