### PR TITLE
feat: move dtl to peerDeps

### DIFF
--- a/projects/testing-library/package.json
+++ b/projects/testing-library/package.json
@@ -32,10 +32,10 @@
     "@angular/common": ">= 17.0.0",
     "@angular/platform-browser": ">= 17.0.0",
     "@angular/router": ">= 17.0.0",
-    "@angular/core": ">= 17.0.0"
+    "@angular/core": ">= 17.0.0",
+    "@testing-library/dom": "^10.0.0"
   },
   "dependencies": {
-    "@testing-library/dom": "^10.0.0",
     "tslib": "^2.3.1"
   },
   "publishConfig": {


### PR DESCRIPTION
BREAKING CHANGE:

`@testing-library/dom` is now a peer dependency of `@testing-library/angular`. This means that you need to install `@testing-library/dom` separately.