### PR TITLE
new option `on` for render and rerender

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, DeferBlockBehavior, DeferBlockState, TestBed } from '
 import { Routes } from '@angular/router';
 import { BoundFunction, Queries, queries, Config as dtlConfig, PrettyDOMOptions } from '@testing-library/dom';
 
-export type SubscribeToOutputsKeysWithCallback<T> = {
+export type OutputRefKeysWithCallback<T> = {
   [key in keyof T as T[key] extends OutputRef<any> ? key : never]?: T[key] extends OutputRef<infer U>
     ? (val: U) => void
     : never;
@@ -66,7 +66,7 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType> extend
   rerender: (
     properties?: Pick<
       RenderTemplateOptions<ComponentType>,
-      'componentProperties' | 'componentInputs' | 'componentOutputs' | 'subscribeToOutputs' | 'detectChangesOnRender'
+      'componentProperties' | 'componentInputs' | 'componentOutputs' | 'on' | 'detectChangesOnRender'
     > & { partialUpdate?: boolean },
   ) => Promise<void>;
   /**
@@ -211,7 +211,7 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   /**
    * @description
    * An object to set `@Output` properties of the component
-   * @deprecated use the `subscribeToOutputs` option instead. When actually wanting to override properties, use the `componentProperties` option.
+   * @deprecated use the `on` option instead. When it is necessary to override properties, use the `componentProperties` option.
    * @default
    * {}
    *
@@ -237,12 +237,12 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * @example
    * const sendValue = (value) => { ... }
    * await render(AppComponent, {
-   *  subscribeToOutputs: {
+   *  on: {
    *    send: (_v:any) => void
    *  }
    * })
    */
-  subscribeToOutputs?: SubscribeToOutputsKeysWithCallback<ComponentType>;
+  on?: OutputRefKeysWithCallback<ComponentType>;
 
   /**
    * @description

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -1,7 +1,13 @@
-import { Type, DebugElement } from '@angular/core';
-import {ComponentFixture, DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
+import { Type, DebugElement, OutputRef } from '@angular/core';
+import { ComponentFixture, DeferBlockBehavior, DeferBlockState, TestBed } from '@angular/core/testing';
 import { Routes } from '@angular/router';
 import { BoundFunction, Queries, queries, Config as dtlConfig, PrettyDOMOptions } from '@testing-library/dom';
+
+export type SubscribeToOutputsKeysWithCallback<T> = {
+  [key in keyof T as T[key] extends OutputRef<any> ? key : never]?: T[key] extends OutputRef<infer U>
+    ? (val: U) => void
+    : never;
+};
 
 export type RenderResultQueries<Q extends Queries = typeof queries> = { [P in keyof Q]: BoundFunction<Q[P]> };
 export interface RenderResult<ComponentType, WrapperType = ComponentType> extends RenderResultQueries {
@@ -60,7 +66,7 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType> extend
   rerender: (
     properties?: Pick<
       RenderTemplateOptions<ComponentType>,
-      'componentProperties' | 'componentInputs' | 'componentOutputs' | 'detectChangesOnRender'
+      'componentProperties' | 'componentInputs' | 'componentOutputs' | 'subscribeToOutputs' | 'detectChangesOnRender'
     > & { partialUpdate?: boolean },
   ) => Promise<void>;
   /**
@@ -205,12 +211,12 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   /**
    * @description
    * An object to set `@Output` properties of the component
-   *
+   * @deprecated use the `subscribeToOutputs` option instead. When actually wanting to override properties, use the `componentProperties` option.
    * @default
    * {}
    *
    * @example
-   * const sendValue = (value) => { ... }
+   * const sendValue = new EventEmitter<any>();
    * await render(AppComponent, {
    *  componentOutputs: {
    *    send: {
@@ -220,6 +226,24 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * })
    */
   componentOutputs?: Partial<ComponentType>;
+
+  /**
+   * @description
+   * An object to subscribe to EventEmitters/Observables of the component
+   *
+   * @default
+   * {}
+   *
+   * @example
+   * const sendValue = (value) => { ... }
+   * await render(AppComponent, {
+   *  subscribeToOutputs: {
+   *    send: (_v:any) => void
+   *  }
+   * })
+   */
+  subscribeToOutputs?: SubscribeToOutputsKeysWithCallback<ComponentType>;
+
   /**
    * @description
    * A collection of providers to inject dependencies of the component.
@@ -379,7 +403,7 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * @description
    * Set the defer blocks behavior.
    */
-  deferBlockBehavior?: DeferBlockBehavior
+  deferBlockBehavior?: DeferBlockBehavior;
 }
 
 export interface ComponentOverride<T> {

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -1,10 +1,12 @@
-import { Type, DebugElement, OutputRef } from '@angular/core';
+import { Type, DebugElement, OutputRef, EventEmitter } from '@angular/core';
 import { ComponentFixture, DeferBlockBehavior, DeferBlockState, TestBed } from '@angular/core/testing';
 import { Routes } from '@angular/router';
 import { BoundFunction, Queries, queries, Config as dtlConfig, PrettyDOMOptions } from '@testing-library/dom';
 
 export type OutputRefKeysWithCallback<T> = {
-  [key in keyof T as T[key] extends OutputRef<any> ? key : never]?: T[key] extends OutputRef<infer U>
+  [key in keyof T]?: T[key] extends EventEmitter<infer U>
+    ? (val: U) => void
+    : T[key] extends OutputRef<infer U>
     ? (val: U) => void
     : never;
 };
@@ -229,7 +231,7 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
 
   /**
    * @description
-   * An object to subscribe to EventEmitters/Observables of the component
+   * An object with callbacks to subscribe to EventEmitters/Observables of the component
    *
    * @default
    * {}

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -187,7 +187,7 @@ describe('componentOutputs', () => {
   });
 });
 
-describe('subscribeToOutputs', () => {
+describe('on', () => {
   @Component({ template: ``, standalone: true })
   class TestFixtureWithEventEmitterComponent {
     @Output() readonly event = new EventEmitter<void>();
@@ -205,7 +205,7 @@ describe('subscribeToOutputs', () => {
 
   it('should subscribe passed listener to the component EventEmitter', async () => {
     const spy = jest.fn();
-    const { fixture } = await render(TestFixtureWithEventEmitterComponent, { subscribeToOutputs: { event: spy } });
+    const { fixture } = await render(TestFixtureWithEventEmitterComponent, { on: { event: spy } });
     fixture.componentInstance.event.emit();
     expect(spy).toHaveBeenCalled();
   });
@@ -213,7 +213,7 @@ describe('subscribeToOutputs', () => {
   it('should unsubscribe on rerender without listener', async () => {
     const spy = jest.fn();
     const { fixture, rerender } = await render(TestFixtureWithEventEmitterComponent, {
-      subscribeToOutputs: { event: spy },
+      on: { event: spy },
     });
 
     await rerender({});
@@ -225,10 +225,10 @@ describe('subscribeToOutputs', () => {
   it('should not unsubscribe when same listener function is used on rerender', async () => {
     const spy = jest.fn();
     const { fixture, rerender } = await render(TestFixtureWithEventEmitterComponent, {
-      subscribeToOutputs: { event: spy },
+      on: { event: spy },
     });
 
-    await rerender({ subscribeToOutputs: { event: spy } });
+    await rerender({ on: { event: spy } });
 
     fixture.componentInstance.event.emit();
     expect(spy).toHaveBeenCalled();
@@ -237,11 +237,11 @@ describe('subscribeToOutputs', () => {
   it('should unsubscribe old and subscribe new listener function on rerender', async () => {
     const firstSpy = jest.fn();
     const { fixture, rerender } = await render(TestFixtureWithEventEmitterComponent, {
-      subscribeToOutputs: { event: firstSpy },
+      on: { event: firstSpy },
     });
 
     const newSpy = jest.fn();
-    await rerender({ subscribeToOutputs: { event: newSpy } });
+    await rerender({ on: { event: newSpy } });
 
     fixture.componentInstance.event.emit();
 
@@ -252,7 +252,7 @@ describe('subscribeToOutputs', () => {
   it('should subscribe passed listener to a derived component output', async () => {
     const spy = jest.fn();
     const { fixture } = await render(TestFixtureWithDerivedEventComponent, {
-      subscribeToOutputs: { event: spy },
+      on: { event: spy },
     });
     fireEvent.click(fixture.nativeElement);
     expect(spy).toHaveBeenCalled();
@@ -261,7 +261,7 @@ describe('subscribeToOutputs', () => {
   it('should subscribe passed listener to a functional component output', async () => {
     const spy = jest.fn();
     const { fixture } = await render(TestFixtureWithFunctionalOutputComponent, {
-      subscribeToOutputs: { event: spy },
+      on: { event: spy },
     });
     fixture.componentInstance.event.emit('test');
     expect(spy).toHaveBeenCalledWith('test');
@@ -274,7 +274,7 @@ describe('subscribeToOutputs', () => {
     }
     const spy = jest.fn();
     const { fixture } = await render(TestFixtureWithFunctionalDerivedEventComponent, {
-      subscribeToOutputs: { event: spy },
+      on: { event: spy },
     });
     fireEvent.click(fixture.nativeElement);
     expect(spy).toHaveBeenCalled();


### PR DESCRIPTION
closes #462

I had to move the `renderFixture` function up the order, as it's necessary to keep track of the `subscribedOutputs` in order to not unnecessarily unsubscribe+resubscribe unchanged listeners when `rerender`ing.