### PR TITLE
refactor: stronger typing of inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,19 @@ counter.component.ts
   selector: 'app-counter',
   template: `
     <button (click)="decrement()">-</button>
-    <span>Current Count: {{ counter }}</span>
+    <span>Current Count: {{ counter() }}</span>
     <button (click)="increment()">+</button>
   `,
 })
 export class CounterComponent {
-  @Input() counter = 0;
+  counter = model(0);
 
   increment() {
-    this.counter += 1;
+    this.counter.set(this.counter() + 1);
   }
 
   decrement() {
-    this.counter -= 1;
+    this.counter.set(this.counter() + 1);
   }
 }
 ```
@@ -126,13 +126,13 @@ import { CounterComponent } from './counter.component';
 
 describe('Counter', () => {
   test('should render counter', async () => {
-    await render(CounterComponent, { componentProperties: { counter: 5 } });
+    await render(CounterComponent, { inputs: { counter: 5 } });
 
     expect(screen.getByText('Current Count: 5'));
   });
 
   test('should increment the counter on click', async () => {
-    await render(CounterComponent, { componentProperties: { counter: 5 } });
+    await render(CounterComponent, { inputs: { counter: 5 } });
 
     const incrementButton = screen.getByRole('button', { name: '+' });
     fireEvent.click(incrementButton);

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export class CounterComponent {
   }
 
   decrement() {
-    this.counter.set(this.counter() + 1);
+    this.counter.set(this.counter() - 1);
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -100,13 +100,15 @@ counter.component.ts
 @Component({
   selector: 'app-counter',
   template: `
+    <span>{{ hello() }}</span>
     <button (click)="decrement()">-</button>
     <span>Current Count: {{ counter() }}</span>
     <button (click)="increment()">+</button>
   `,
 })
-export class CounterComponent {
+class CounterComponent {
   counter = model(0);
+  hello = input('Hi', { alias: 'greeting' });
 
   increment() {
     this.counter.set(this.counter() + 1);
@@ -121,23 +123,30 @@ export class CounterComponent {
 counter.component.spec.ts
 
 ```typescript
-import { render, screen, fireEvent } from '@testing-library/angular';
+import { render, screen, fireEvent, aliasedInput } from '@testing-library/angular';
 import { CounterComponent } from './counter.component';
 
 describe('Counter', () => {
-  test('should render counter', async () => {
-    await render(CounterComponent, { inputs: { counter: 5 } });
+  it('should render counter', async () => {
+    await render(CounterComponent, {
+      inputs: {
+        counter: 5,
+        // aliases need to be specified this way
+        ...aliasedInput('greeting', 'Hello Alias!'),
+      },
+    });
 
-    expect(screen.getByText('Current Count: 5'));
+    expect(screen.getByText('Current Count: 5')).toBeVisible();
+    expect(screen.getByText('Hello Alias!')).toBeVisible();
   });
 
-  test('should increment the counter on click', async () => {
+  it('should increment the counter on click', async () => {
     await render(CounterComponent, { inputs: { counter: 5 } });
 
     const incrementButton = screen.getByRole('button', { name: '+' });
     fireEvent.click(incrementButton);
 
-    expect(screen.getByText('Current Count: 6'));
+    expect(screen.getByText('Current Count: 6')).toBeVisible();
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ counter.component.ts
     <button (click)="increment()">+</button>
   `,
 })
-class CounterComponent {
+export class CounterComponent {
   counter = model(0);
   hello = input('Hi', { alias: 'greeting' });
 

--- a/apps/example-app/src/app/examples/02-input-output.spec.ts
+++ b/apps/example-app/src/app/examples/02-input-output.spec.ts
@@ -8,7 +8,7 @@ test('is possible to set input and listen for output', async () => {
   const sendValue = jest.fn();
 
   await render(InputOutputComponent, {
-    componentInputs: {
+    inputs: {
       value: 47,
     },
     on: {
@@ -64,7 +64,7 @@ test('is possible to set input and listen for output (deprecated)', async () => 
   const sendValue = jest.fn();
 
   await render(InputOutputComponent, {
-    componentInputs: {
+    inputs: {
       value: 47,
     },
     componentOutputs: {

--- a/apps/example-app/src/app/examples/22-signal-inputs.component.spec.ts
+++ b/apps/example-app/src/app/examples/22-signal-inputs.component.spec.ts
@@ -1,11 +1,11 @@
-import { render, screen, within } from '@testing-library/angular';
+import { aliasedInputWithValue, render, screen, within } from '@testing-library/angular';
 import { SignalInputComponent } from './22-signal-inputs.component';
 import userEvent from '@testing-library/user-event';
 
 test('works with signal inputs', async () => {
   await render(SignalInputComponent, {
-    componentInputs: {
-      greeting: 'Hello',
+    inputs: {
+      greeting: aliasedInputWithValue('Hello'),
       name: 'world',
     },
   });
@@ -16,8 +16,8 @@ test('works with signal inputs', async () => {
 
 test('works with computed', async () => {
   await render(SignalInputComponent, {
-    componentInputs: {
-      greeting: 'Hello',
+    inputs: {
+      greeting: aliasedInputWithValue('Hello'),
       name: 'world',
     },
   });
@@ -28,8 +28,8 @@ test('works with computed', async () => {
 
 test('can update signal inputs', async () => {
   const { fixture } = await render(SignalInputComponent, {
-    componentInputs: {
-      greeting: 'Hello',
+    inputs: {
+      greeting: aliasedInputWithValue('Hello'),
       name: 'world',
     },
   });
@@ -51,8 +51,8 @@ test('can update signal inputs', async () => {
 test('output emits a value', async () => {
   const submitFn = jest.fn();
   await render(SignalInputComponent, {
-    componentInputs: {
-      greeting: 'Hello',
+    inputs: {
+      greeting: aliasedInputWithValue('Hello'),
       name: 'world',
     },
     on: {
@@ -67,8 +67,8 @@ test('output emits a value', async () => {
 
 test('model update also updates the template', async () => {
   const { fixture } = await render(SignalInputComponent, {
-    componentInputs: {
-      greeting: 'Hello',
+    inputs: {
+      greeting: aliasedInputWithValue('Hello'),
       name: 'initial',
     },
   });
@@ -97,8 +97,8 @@ test('model update also updates the template', async () => {
 
 test('works with signal inputs, computed values, and rerenders', async () => {
   const view = await render(SignalInputComponent, {
-    componentInputs: {
-      greeting: 'Hello',
+    inputs: {
+      greeting: aliasedInputWithValue('Hello'),
       name: 'world',
     },
   });
@@ -110,8 +110,8 @@ test('works with signal inputs, computed values, and rerenders', async () => {
   expect(computedValue.getByText(/hello world/i)).toBeInTheDocument();
 
   await view.rerender({
-    componentInputs: {
-      greeting: 'bye',
+    inputs: {
+      greeting: aliasedInputWithValue('bye'),
       name: 'test',
     },
   });

--- a/apps/example-app/src/app/examples/22-signal-inputs.component.spec.ts
+++ b/apps/example-app/src/app/examples/22-signal-inputs.component.spec.ts
@@ -1,11 +1,11 @@
-import { aliasedInputWithValue, render, screen, within } from '@testing-library/angular';
+import { aliasedInput, render, screen, within } from '@testing-library/angular';
 import { SignalInputComponent } from './22-signal-inputs.component';
 import userEvent from '@testing-library/user-event';
 
 test('works with signal inputs', async () => {
   await render(SignalInputComponent, {
     inputs: {
-      greeting: aliasedInputWithValue('Hello'),
+      ...aliasedInput('greeting', 'Hello'),
       name: 'world',
     },
   });
@@ -17,7 +17,7 @@ test('works with signal inputs', async () => {
 test('works with computed', async () => {
   await render(SignalInputComponent, {
     inputs: {
-      greeting: aliasedInputWithValue('Hello'),
+      ...aliasedInput('greeting', 'Hello'),
       name: 'world',
     },
   });
@@ -29,7 +29,7 @@ test('works with computed', async () => {
 test('can update signal inputs', async () => {
   const { fixture } = await render(SignalInputComponent, {
     inputs: {
-      greeting: aliasedInputWithValue('Hello'),
+      ...aliasedInput('greeting', 'Hello'),
       name: 'world',
     },
   });
@@ -52,7 +52,7 @@ test('output emits a value', async () => {
   const submitFn = jest.fn();
   await render(SignalInputComponent, {
     inputs: {
-      greeting: aliasedInputWithValue('Hello'),
+      ...aliasedInput('greeting', 'Hello'),
       name: 'world',
     },
     on: {
@@ -68,7 +68,7 @@ test('output emits a value', async () => {
 test('model update also updates the template', async () => {
   const { fixture } = await render(SignalInputComponent, {
     inputs: {
-      greeting: aliasedInputWithValue('Hello'),
+      ...aliasedInput('greeting', 'Hello'),
       name: 'initial',
     },
   });
@@ -98,7 +98,7 @@ test('model update also updates the template', async () => {
 test('works with signal inputs, computed values, and rerenders', async () => {
   const view = await render(SignalInputComponent, {
     inputs: {
-      greeting: aliasedInputWithValue('Hello'),
+      ...aliasedInput('greeting', 'Hello'),
       name: 'world',
     },
   });
@@ -111,7 +111,7 @@ test('works with signal inputs, computed values, and rerenders', async () => {
 
   await view.rerender({
     inputs: {
-      greeting: aliasedInputWithValue('bye'),
+      ...aliasedInput('greeting', 'bye'),
       name: 'test',
     },
   });

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -95,8 +95,8 @@ export type ComponentInput<T> =
  * Creates an aliased input branded type with a value
  *
  */
-export function aliasedInputWithValue<T>(value: T): AliasedInput<T> {
-  return value as AliasedInput<T>;
+export function aliasedInput<TAlias extends string, T>(alias: TAlias, value: T): Record<TAlias, AliasedInput<T>> {
+  return { [alias]: value } as Record<TAlias, AliasedInput<T>>;
 }
 
 export interface RenderComponentOptions<ComponentType, Q extends Queries = typeof queries> {
@@ -220,7 +220,7 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * @description
    * An object to set `@Input` properties of the component
    *
-   * @deprecated use the `inputs` option instead. When you need to use aliases, use the `aliasedInputWithValue(...)` helper function.
+   * @deprecated use the `inputs` option instead. When you need to use aliases, use the `aliasedInput(...)` helper function.
    * @default
    * {}
    *
@@ -245,7 +245,7 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * inputs: {
    *  counterValue: 10,
    *  // explicitly define aliases this way:
-   *  someAlias: aliasedInputWithValue('value')
+   *  ...aliasedInput('someAlias', 'someValue')
    * })
    */
   inputs?: ComponentInput<ComponentType>;

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -244,8 +244,9 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
    * await render(AppComponent, {
    * inputs: {
    *  counterValue: 10,
+   *  // explicitly define aliases this way:
    *  someAlias: aliasedInputWithValue('value')
-   * }
+   * })
    */
   inputs?: ComponentInput<ComponentType>;
 

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -86,9 +86,7 @@ export type AliasedInputs = Record<string, AliasedInput<unknown>>;
 
 export type ComponentInput<T> =
   | {
-      [P in keyof T]?: T[P] extends Signal<infer U>
-        ? U // If the property is a Signal, apply Partial to the inner type
-        : Partial<T[P]>; // Otherwise, apply Partial to the property itself
+      [P in keyof T]?: T[P] extends Signal<infer U> ? U : T[P];
     }
   | AliasedInputs;
 

--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -68,7 +68,7 @@ export interface RenderResult<ComponentType, WrapperType = ComponentType> extend
   rerender: (
     properties?: Pick<
       RenderTemplateOptions<ComponentType>,
-      'componentProperties' | 'componentInputs' | 'componentOutputs' | 'on' | 'detectChangesOnRender'
+      'componentProperties' | 'componentInputs' | 'inputs' | 'componentOutputs' | 'on' | 'detectChangesOnRender'
     > & { partialUpdate?: boolean },
   ) => Promise<void>;
   /**

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -67,6 +67,7 @@ export async function render<SutType, WrapperType = SutType>(
     componentProperties = {},
     componentInputs = {},
     componentOutputs = {},
+    inputs: newInputs = {},
     on = {},
     componentProviders = [],
     childComponentOverrides = [],
@@ -176,8 +177,10 @@ export async function render<SutType, WrapperType = SutType>(
 
   let detectChanges: () => void;
 
+  const allInputs = { ...componentInputs, ...newInputs };
+
   let renderedPropKeys = Object.keys(componentProperties);
-  let renderedInputKeys = Object.keys(componentInputs);
+  let renderedInputKeys = Object.keys(allInputs);
   let renderedOutputKeys = Object.keys(componentOutputs);
   let subscribedOutputs: SubscribedOutput<SutType>[] = [];
 
@@ -224,7 +227,7 @@ export async function render<SutType, WrapperType = SutType>(
     return createdFixture;
   };
 
-  const fixture = await renderFixture(componentProperties, componentInputs, componentOutputs, on);
+  const fixture = await renderFixture(componentProperties, allInputs, componentOutputs, on);
 
   if (deferBlockStates) {
     if (Array.isArray(deferBlockStates)) {

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -242,10 +242,10 @@ export async function render<SutType, WrapperType = SutType>(
   const rerender = async (
     properties?: Pick<
       RenderTemplateOptions<SutType>,
-      'componentProperties' | 'componentInputs' | 'componentOutputs' | 'on' | 'detectChangesOnRender'
+      'componentProperties' | 'componentInputs' | 'inputs' | 'componentOutputs' | 'on' | 'detectChangesOnRender'
     > & { partialUpdate?: boolean },
   ) => {
-    const newComponentInputs = properties?.componentInputs ?? {};
+    const newComponentInputs = { ...properties?.componentInputs, ...properties?.inputs };
     const changesInComponentInput = update(
       fixture,
       renderedInputKeys,

--- a/projects/testing-library/tests/integrations/ng-mocks.spec.ts
+++ b/projects/testing-library/tests/integrations/ng-mocks.spec.ts
@@ -8,7 +8,7 @@ import { NgIf } from '@angular/common';
 test('sends the correct value to the child input', async () => {
   const utils = await render(TargetComponent, {
     imports: [MockComponent(ChildComponent)],
-    componentInputs: { value: 'foo' },
+    inputs: { value: 'foo' },
   });
 
   const children = utils.fixture.debugElement.queryAll(By.directive(ChildComponent));
@@ -21,7 +21,7 @@ test('sends the correct value to the child input', async () => {
 test('sends the correct value to the child input 2', async () => {
   const utils = await render(TargetComponent, {
     imports: [MockComponent(ChildComponent)],
-    componentInputs: { value: 'bar' },
+    inputs: { value: 'bar' },
   });
 
   const children = utils.fixture.debugElement.queryAll(By.directive(ChildComponent));

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -559,21 +559,29 @@ describe('inputs and signals', () => {
   });
 
   it('should typecheck correctly', async () => {
-    // @ts-expect-error - myName is a string
-    await render(InputComponent, {
-      inputs: {
-        myName: 123,
-      },
-    });
+    // we only want to check the types here
+    // so we are purposely not calling render
 
-    // @ts-expect-error - job is not using aliasedInputWithValue
-    await render(InputComponent, {
-      inputs: {
-        job: 'not used with aliasedInputWithValue',
+    const typeTests = [
+      () => {
+        // @ts-expect-error - myName is a string
+        await render(InputComponent, {
+          inputs: {
+            myName: 123,
+          },
+        });
       },
-    });
+      () => {
+        // @ts-expect-error - job is not using aliasedInputWithValue
+        await render(InputComponent, {
+          inputs: {
+            job: 'not used with aliasedInputWithValue',
+          },
+        });
+      },
+    ];
 
     // add a statement so the test succeeds
-    expect(true).toBeTruthy();
+    expect(typeTests).toBeTruthy();
   });
 });

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -623,7 +623,7 @@ describe('README examples', () => {
       }
 
       decrement() {
-        this.counter.set(this.counter() + 1);
+        this.counter.set(this.counter() - 1);
       }
     }
 

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -564,10 +564,26 @@ describe('inputs and signals', () => {
 
     const typeTests = [
       async () => {
+        // OK:
+        await render(InputComponent, {
+          inputs: {
+            myName: 'OK',
+          },
+        });
+      },
+      async () => {
         // @ts-expect-error - myName is a string
         await render(InputComponent, {
           inputs: {
             myName: 123,
+          },
+        });
+      },
+      async () => {
+        // OK:
+        await render(InputComponent, {
+          inputs: {
+            job: aliasedInputWithValue('OK'),
           },
         });
       },

--- a/projects/testing-library/tests/render.spec.ts
+++ b/projects/testing-library/tests/render.spec.ts
@@ -563,7 +563,7 @@ describe('inputs and signals', () => {
     // so we are purposely not calling render
 
     const typeTests = [
-      () => {
+      async () => {
         // @ts-expect-error - myName is a string
         await render(InputComponent, {
           inputs: {
@@ -571,7 +571,7 @@ describe('inputs and signals', () => {
           },
         });
       },
-      () => {
+      async () => {
         // @ts-expect-error - job is not using aliasedInputWithValue
         await render(InputComponent, {
           inputs: {

--- a/projects/testing-library/tests/rerender.spec.ts
+++ b/projects/testing-library/tests/rerender.spec.ts
@@ -43,7 +43,7 @@ test('rerenders the component with updated inputs', async () => {
   expect(screen.getByText('Sarah')).toBeInTheDocument();
 
   const firstName = 'Mark';
-  await rerender({ componentInputs: { firstName } });
+  await rerender({ inputs: { firstName } });
 
   expect(screen.getByText(firstName)).toBeInTheDocument();
 });
@@ -52,7 +52,7 @@ test('rerenders the component with updated inputs and resets other props', async
   const firstName = 'Mark';
   const lastName = 'Peeters';
   const { rerender } = await render(FixtureComponent, {
-    componentInputs: {
+    inputs: {
       firstName,
       lastName,
     },
@@ -61,7 +61,7 @@ test('rerenders the component with updated inputs and resets other props', async
   expect(screen.getByText(`${firstName} ${lastName}`)).toBeInTheDocument();
 
   const firstName2 = 'Chris';
-  await rerender({ componentInputs: { firstName: firstName2 } });
+  await rerender({ inputs: { firstName: firstName2 } });
 
   expect(screen.getByText(firstName2)).toBeInTheDocument();
   expect(screen.queryByText(firstName)).not.toBeInTheDocument();
@@ -87,7 +87,7 @@ test('rerenders the component with updated inputs and keeps other props when par
   const firstName = 'Mark';
   const lastName = 'Peeters';
   const { rerender } = await render(FixtureComponent, {
-    componentInputs: {
+    inputs: {
       firstName,
       lastName,
     },
@@ -96,7 +96,7 @@ test('rerenders the component with updated inputs and keeps other props when par
   expect(screen.getByText(`${firstName} ${lastName}`)).toBeInTheDocument();
 
   const firstName2 = 'Chris';
-  await rerender({ componentInputs: { firstName: firstName2 }, partialUpdate: true });
+  await rerender({ inputs: { firstName: firstName2 }, partialUpdate: true });
 
   expect(screen.queryByText(firstName)).not.toBeInTheDocument();
   expect(screen.getByText(`${firstName2} ${lastName}`)).toBeInTheDocument();
@@ -181,7 +181,7 @@ test('change detection gets not called if `detectChangesOnRender` is set to fals
   expect(screen.getByText('Sarah')).toBeInTheDocument();
 
   const firstName = 'Mark';
-  await rerender({ componentInputs: { firstName }, detectChangesOnRender: false });
+  await rerender({ inputs: { firstName }, detectChangesOnRender: false });
 
   expect(screen.getByText('Sarah')).toBeInTheDocument();
   expect(screen.queryByText(firstName)).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes #464 

This PR restores the type safety of inputs and introduces a new property called `inputs` and deprecates `componentInputs`. Previously we had an union with `{ [alias: string]: unknown }` which would essentially act as `any`.

We add a branded type through which aliases can be explicitly supplied.

Usage:

```ts
  @Component({
    selector: 'atl-fixture',
    template: `<span>{{ myName() }}</span> <span>{{ myJob() }}</span>`,
  })
  class InputComponent {
    myName = input('foo');

    myJob = input('bar', { alias: 'job' });
  }

  it('should set the input component', async () => {
    await render(InputComponent, {
      inputs: {
        myName: 'Bob',
        job: aliasedInputWithValue('Builder'),
      },
    });

    expect(screen.getByText('Bob')).toBeInTheDocument();
    expect(screen.getByText('Builder')).toBeInTheDocument();
  });
```