### PR TITLE
fix: make wrapper component `standalone: false` explicitly

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -473,6 +473,7 @@ export interface RenderTemplateOptions<WrapperType, Properties extends object = 
    * @description
    * An Angular component to wrap the component in.
    * The template will be overridden with the `template` option.
+   * NOTE: A standalone component cannot be used as a wrapper.
    *
    * @default
    * `WrapperComponent`, an empty component that strips the `ng-version` attribute

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -616,7 +616,7 @@ if (typeof process === 'undefined' || !process.env?.ATL_SKIP_AUTO_CLEANUP) {
   }
 }
 
-@Component({ selector: 'atl-wrapper-component', template: '' })
+@Component({ selector: 'atl-wrapper-component', template: '', standalone: false })
 class WrapperComponent {}
 
 /**


### PR DESCRIPTION
Since Angular v19, components are set as standalone: true by default, but ATL is currently supporting only non-standalone wrapper. For forward-compatibility, make default wrapper `standalone: false` explicitly.