### PR TITLE
fix: flatten component providers for consistency to the framework

### DIFF
--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -119,7 +119,8 @@ export async function render<SutType, WrapperType = SutType>(
 
   await TestBed.compileComponents();
 
-  for (const { provide, ...provider } of componentProviders) {
+  // Angular supports nested arrays of providers, so we need to flatten them to emulate the same behavior.
+  for (const { provide, ...provider } of componentProviders.flat(Infinity)) {
     TestBed.overrideProvider(provide, provider);
   }
 

--- a/projects/testing-library/tests/providers/component-provider.spec.ts
+++ b/projects/testing-library/tests/providers/component-provider.spec.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Provider } from '@angular/core';
 import { Component } from '@angular/core';
 import { render, screen } from '../../src/public_api';
 
@@ -37,6 +37,24 @@ test('shows the provided service value with template syntax', async () => {
         },
       },
     ],
+  });
+
+  expect(screen.getByText('bar')).toBeInTheDocument();
+});
+
+test('flatten the nested array of component providers', async () => {
+  const provideService = (): Provider => [
+    {
+      provide: Service,
+      useValue: {
+        foo() {
+          return 'bar';
+        },
+      },
+    },
+  ];
+  await render(FixtureComponent, {
+    componentProviders: [provideService()],
   });
 
   expect(screen.getByText('bar')).toBeInTheDocument();


### PR DESCRIPTION
Close #506

fyi: In contrast to `componentProviders`, `providers` is just passed into TestBed's module configuration. So it is treated by Angular itself and flattened correctly.