### PR TITLE
fix: do not force npm to install dependencies when using `ng add`

### DIFF
--- a/projects/testing-library/schematics/ng-add/index.ts
+++ b/projects/testing-library/schematics/ng-add/index.ts
@@ -32,9 +32,9 @@ function addDependency(packageName: string, version: string, dependencyType: Nod
   };
 }
 
-export function installDependencies(packageManager = 'npm') {
+export function installDependencies() {
   return (_tree: Tree, context: SchematicContext) => {
-    context.addTask(new NodePackageInstallTask({ packageManager }));
+    context.addTask(new NodePackageInstallTask());
 
     context.logger.info(
       `Correctly installed @testing-library/angular.


### PR DESCRIPTION
let Angular CLI decide which package manager to use to install the dependencies based on the configuration in `angular.json` file (default is "npm").

fixes #513