### PR TITLE
feat: undeprecate componentProperties

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -215,7 +215,7 @@ export interface RenderComponentOptions<ComponentType, Q extends Queries = typeo
   /**
    * @description
    * An object to set properties of the component
-   * @deprecated use the `on` or `inputs` option instead.
+   *
    * @default
    * {}
    *


### PR DESCRIPTION
There are some cases where it's useful to be able to set properties.
Examples are:
 - templates
 - setting properties which aren't decorated as inputs

Closes #470