### PR TITLE
fix: fix config for testing with zoneless Angular

### DIFF
--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -108,9 +108,11 @@ export async function render<SutType, WrapperType = SutType>(
     imports: addAutoImports(sut, {
       imports: imports.concat(defaultImports),
       routes,
+    }),
+    providers: addAutoProviders({
+      providers: [...providers],
       zoneless,
     }),
-    providers: [...providers],
     schemas: [...schemas],
     deferBlockBehavior: deferBlockBehavior ?? DeferBlockBehavior.Manual,
   });
@@ -514,16 +516,19 @@ function addAutoDeclarations<SutType>(
 
 function addAutoImports<SutType>(
   sut: Type<SutType> | string,
-  {
-    imports = [],
-    routes,
-    zoneless,
-  }: Pick<RenderComponentOptions<any>, 'imports' | 'routes'> & Pick<Config, 'zoneless'>,
+  { imports = [], routes }: Pick<RenderComponentOptions<any>, 'imports' | 'routes'>,
 ) {
   const routing = () => (routes ? [RouterTestingModule.withRoutes(routes)] : []);
   const components = () => (typeof sut !== 'string' && isStandalone(sut) ? [sut] : []);
+  return [...imports, ...components(), ...routing()];
+}
+
+function addAutoProviders({
+  providers = [],
+  zoneless,
+}: Pick<RenderTemplateOptions<any>, 'providers'> & Pick<Config, 'zoneless'>) {
   const provideZoneless = () => (zoneless ? [provideZonelessChangeDetection()] : []);
-  return [...imports, ...components(), ...routing(), ...provideZoneless()];
+  return [...providers, ...provideZoneless()];
 }
 
 async function renderDeferBlock<SutType>(


### PR DESCRIPTION
This PR fixes zoneless flag in the configure function. I tried to use the configure function with zoneless flag

```typescript
function setup() {
  configure({ zoneless: true });
  return render(MyComponent);
}
```

but I got error `Unexpected value 'undefined' imported by the module 'DynamicTestModule'. Please add an @NgModule annotation.`

This is because `provideZonelessChangeDetection` is incorrectly used inside `imports` instead of `providers`.

