### PR TITLE
fix: re-add zoneless for render

### DIFF
--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -11,6 +11,7 @@ import {
   SimpleChanges,
   Type,
   isStandalone,
+  provideZonelessChangeDetection,
 } from '@angular/core';
 import { ComponentFixture, DeferBlockBehavior, DeferBlockState, TestBed, tick } from '@angular/core/testing';
 import { NavigationExtras, Router } from '@angular/router';
@@ -79,6 +80,7 @@ export async function render<SutType, WrapperType = SutType>(
     initialRoute = '',
     deferBlockStates = undefined,
     deferBlockBehavior = undefined,
+    zoneless = false,
     configureTestBed = () => {
       /* noop*/
     },
@@ -107,7 +109,10 @@ export async function render<SutType, WrapperType = SutType>(
       imports: imports.concat(defaultImports),
       routes,
     }),
-    providers,
+    providers: addAutoProviders({
+      providers: [...providers],
+      zoneless,
+    }),
     schemas: [...schemas],
     deferBlockBehavior: deferBlockBehavior ?? DeferBlockBehavior.Manual,
   });
@@ -516,6 +521,14 @@ function addAutoImports<SutType>(
   const routing = () => (routes ? [RouterTestingModule.withRoutes(routes)] : []);
   const components = () => (typeof sut !== 'string' && isStandalone(sut) ? [sut] : []);
   return [...imports, ...components(), ...routing()];
+}
+
+function addAutoProviders({
+  providers = [],
+  zoneless,
+}: Pick<RenderTemplateOptions<any>, 'providers'> & Pick<Config, 'zoneless'>) {
+  const provideZoneless = () => (zoneless ? [provideZonelessChangeDetection()] : []);
+  return [...providers, ...provideZoneless()];
 }
 
 async function renderDeferBlock<SutType>(


### PR DESCRIPTION
This allows to set the zoneless option on the `render` method