### PR TITLE
fix: include custom queries in RenderResult type

### DIFF
--- a/projects/testing-library/src/lib/models.ts
+++ b/projects/testing-library/src/lib/models.ts
@@ -30,7 +30,13 @@ export type OutputRefKeysWithCallback<T> = {
 };
 
 export type RenderResultQueries<Q extends Queries = typeof queries> = BoundFunctions<Q>;
-export interface RenderResult<ComponentType, WrapperType = ComponentType> extends RenderResultQueries {
+export type RenderResult<
+  ComponentType,
+  WrapperType = ComponentType,
+  Q extends Queries = typeof queries,
+> = RenderResultQueries<Q> & BaseRenderResult<ComponentType, WrapperType>;
+
+interface BaseRenderResult<ComponentType, WrapperType = ComponentType> {
   /**
    * @description
    * The containing DOM node of your rendered Angular Component.

--- a/projects/testing-library/src/lib/testing-library.ts
+++ b/projects/testing-library/src/lib/testing-library.ts
@@ -44,19 +44,19 @@ type SubscribedOutput<T> = readonly [key: keyof T, callback: (v: any) => void, s
 
 const mountedFixtures = new Set<ComponentFixture<any>>();
 
-export async function render<ComponentType>(
+export async function render<ComponentType, Q extends Queries = typeof dtlQueries>(
   component: Type<ComponentType>,
-  renderOptions?: RenderComponentOptions<ComponentType>,
-): Promise<RenderResult<ComponentType, ComponentType>>;
-export async function render<WrapperType = WrapperComponent>(
+  renderOptions?: RenderComponentOptions<ComponentType, Q>,
+): Promise<RenderResult<ComponentType, ComponentType, Q>>;
+export async function render<WrapperType = WrapperComponent, Q extends Queries = typeof dtlQueries>(
   template: string,
-  renderOptions?: RenderTemplateOptions<WrapperType>,
-): Promise<RenderResult<WrapperType>>;
+  renderOptions?: RenderTemplateOptions<WrapperType, object, Q>,
+): Promise<RenderResult<WrapperType, WrapperType, Q>>;
 
-export async function render<SutType, WrapperType = SutType>(
+export async function render<SutType, WrapperType = SutType, Q extends Queries = typeof dtlQueries>(
   sut: Type<SutType> | string,
-  renderOptions: RenderComponentOptions<SutType> | RenderTemplateOptions<WrapperType> = {},
-): Promise<RenderResult<SutType>> {
+  renderOptions: RenderComponentOptions<SutType, Q> | RenderTemplateOptions<WrapperType, object, Q> = {},
+): Promise<RenderResult<SutType, SutType, Q>> {
   const { dom: domConfig, ...globalConfig } = getConfig();
   const {
     detectChangesOnRender = true,
@@ -87,8 +87,8 @@ export async function render<SutType, WrapperType = SutType>(
     configureTestBed = () => {
       /* noop*/
     },
-  } = { ...globalConfig, ...renderOptions } as RenderComponentOptions<SutType> &
-    RenderTemplateOptions<WrapperType> &
+  } = { ...globalConfig, ...renderOptions } as RenderComponentOptions<SutType, Q> &
+    RenderTemplateOptions<WrapperType, object, Q> &
     Config;
 
   dtlConfigure({
@@ -362,8 +362,8 @@ export async function render<SutType, WrapperType = SutType>(
         console.log(dtlPrettyDOM(element, maxLength, options));
       }
     },
-    ...replaceFindWithFindAndDetectChanges(dtlGetQueriesForElement(fixture.nativeElement, queries)),
-  };
+    ...replaceFindWithFindAndDetectChanges(dtlGetQueriesForElement<Q>(fixture.nativeElement, queries)),
+  } as RenderResult<SutType, SutType, Q>;
 }
 
 async function createComponent<SutType>(

--- a/projects/testing-library/src/tests/issues/issue-590.spec.ts
+++ b/projects/testing-library/src/tests/issues/issue-590.spec.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { test, expect } from 'vitest';
+import { render, queries, queryHelpers } from '../../public_api';
+
+const myQueryByTestId = queryHelpers.queryByAttribute.bind(null, 'data-test-id');
+
+test('custom queries passed to render are available on the render result', async () => {
+  const view = await render(FixtureComponent, {
+    queries: {
+      ...queries,
+      myQueryByTestId,
+    },
+  });
+
+  expect(view.myQueryByTestId('my-fixture')).not.toBeNull();
+  // eslint-disable-next-line testing-library/prefer-screen-queries
+  expect(view.myQueryByTestId('my-fixture')).toBe(view.getByText('Hello world'));
+});
+
+@Component({
+  selector: 'atl-fixture',
+  template: `<div data-test-id="my-fixture">Hello world</div>`,
+})
+class FixtureComponent {}

--- a/projects/testing-library/zoneless/src/public_api.ts
+++ b/projects/testing-library/zoneless/src/public_api.ts
@@ -18,7 +18,13 @@ import {
 
 export type RenderResultQueries<Q extends Queries = typeof queries> = BoundFunctions<Q>;
 
-export interface RenderResult<ComponentType, WrapperType = ComponentType> extends RenderResultQueries {
+export type RenderResult<
+  ComponentType,
+  WrapperType = ComponentType,
+  Q extends Queries = typeof queries,
+> = RenderResultQueries<Q> & BaseRenderResult<ComponentType, WrapperType>;
+
+interface BaseRenderResult<ComponentType, WrapperType = ComponentType> {
   /**
    * @description
    * The containing DOM node of your rendered Angular Component.
@@ -206,28 +212,28 @@ export interface RenderTemplateOptions<WrapperType, Properties extends object = 
   imports?: any[];
 }
 
-export async function render<ComponentType>(
+export async function render<ComponentType, Q extends Queries = typeof queries>(
   component: Type<ComponentType>,
-  renderOptions?: RenderComponentOptions,
-): Promise<RenderResult<ComponentType, ComponentType>>;
-export async function render<WrapperType = WrapperComponent>(
+  renderOptions?: RenderComponentOptions<Q>,
+): Promise<RenderResult<ComponentType, ComponentType, Q>>;
+export async function render<WrapperType = WrapperComponent, Q extends Queries = typeof queries>(
   template: string,
-  renderOptions?: RenderTemplateOptions<WrapperType>,
-): Promise<RenderResult<WrapperType>>;
-export async function render<ComponentType, WrapperType = ComponentType>(
+  renderOptions?: RenderTemplateOptions<WrapperType, object, Q>,
+): Promise<RenderResult<WrapperType, WrapperType, Q>>;
+export async function render<ComponentType, WrapperType = ComponentType, Q extends Queries = typeof queries>(
   componentOrTemplate: Type<ComponentType> | string,
-  renderOptions: RenderComponentOptions | RenderTemplateOptions<WrapperType> = {},
-): Promise<RenderResult<ComponentType, ComponentType | WrapperType>> {
+  renderOptions: RenderComponentOptions<Q> | RenderTemplateOptions<WrapperType, object, Q> = {},
+): Promise<RenderResult<ComponentType, ComponentType | WrapperType, Q>> {
   TestBed.configureTestingModule({
     declarations: [WrapperComponent],
     imports: 'imports' in renderOptions ? renderOptions.imports : [],
     providers: renderOptions.providers ?? [],
   });
 
-  if ('importOverrides' in renderOptions && (renderOptions as RenderComponentOptions).importOverrides?.length) {
+  if ('importOverrides' in renderOptions && (renderOptions as RenderComponentOptions<Q>).importOverrides?.length) {
     const sut = componentOrTemplate as Type<unknown>;
     if (typeof sut === 'function' && isStandalone(sut)) {
-      const overrides = (renderOptions as RenderComponentOptions).importOverrides!;
+      const overrides = (renderOptions as RenderComponentOptions<Q>).importOverrides!;
       TestBed.overrideComponent(sut, {
         remove: { imports: overrides.map((o) => o.replace) },
         add: { imports: overrides.map((o) => o.with) },
@@ -267,8 +273,8 @@ export async function render<ComponentType, WrapperType = ComponentType>(
         console.log(prettyDOM(element, maxLength, options));
       }
     },
-    ...getQueriesForElement(fixture.nativeElement, renderOptions?.queries),
-  };
+    ...getQueriesForElement<Q>(fixture.nativeElement, renderOptions?.queries),
+  } as RenderResult<ComponentType, ComponentType | WrapperType, Q>;
 }
 
 async function createComponentFixture<SutType>(

--- a/projects/testing-library/zoneless/tests/zoneless.spec.ts
+++ b/projects/testing-library/zoneless/tests/zoneless.spec.ts
@@ -1,7 +1,7 @@
 import { Component, inject, Injectable, model, output, outputBinding, signal, twoWayBinding } from '@angular/core';
 import { test, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '../index';
+import { render, screen, queries, queryHelpers } from '../index';
 
 @Injectable()
 class CounterService {
@@ -249,4 +249,25 @@ test('can provide custom service providers', async () => {
 
   await user.click(decrementControl);
   expect(counterControl).toHaveTextContent('1');
+});
+
+@Component({
+  selector: 'atl-custom-query-fixture',
+  template: `<div data-test-id="my-fixture">Hello world</div>`,
+})
+class CustomQueryFixtureComponent {}
+
+test('custom queries passed to render are available on the render result', async () => {
+  const myQueryByTestId = queryHelpers.queryByAttribute.bind(null, 'data-test-id');
+
+  const view = await render(CustomQueryFixtureComponent, {
+    queries: {
+      ...queries,
+      myQueryByTestId,
+    },
+  });
+
+  expect(view.myQueryByTestId('my-fixture')).not.toBeNull();
+  // eslint-disable-next-line testing-library/prefer-screen-queries
+  expect(view.myQueryByTestId('my-fixture')).toBe(view.getByText('Hello world'));
 });


### PR DESCRIPTION
## What

Custom queries passed to `render` via the `queries` option are now reflected on the returned `RenderResult` type.

Closes #590

## Why

`RenderResult` extended `RenderResultQueries` with the default DOM Testing Library queries hardcoded, so TypeScript rejected custom query members even though they exist at runtime:

```ts
const view = await render(MyComponent, {
  queries: { ...queries, myQueryByTestId },
});

view.myQueryByTestId('foo');
// Property 'myQueryByTestId' does not exist on type 'RenderResult<MyComponent, MyComponent>'.
```

## How

- `RenderResult` gains a third generic `Q extends Queries = typeof queries`. Since an interface cannot `extends` the generically-mapped `BoundFunctions<Q>`, it is now a type alias intersecting `RenderResultQueries<Q>` with the (internal) `BaseRenderResult` interface holding the original members — as suggested in the issue.
- The `render` overloads infer `Q` from `renderOptions.queries` and thread it through to the return type.
- Added a regression test reproducing the issue's scenario ([issue-590.spec.ts](https://github.com/testing-library/angular-testing-library/blob/fix/590-custom-queries-render-result/projects/testing-library/src/tests/issues/issue-590.spec.ts)) — it does not compile without this fix.

`Q` defaults to the standard queries, so existing usage is unaffected. Minor caveat: declaration merging on `RenderResult` no longer works since it is a type alias now, but `interface X extends RenderResult<T>` with concrete type arguments still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)