### PR TITLE
fix: replace deprecated animation and testing-module APIs

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -170,7 +170,10 @@
           "defaultConfiguration": "development"
         },
         "test": {
-          "builder": "@angular-builders/jest:run"
+          "builder": "@angular-builders/jest:run",
+          "options": {
+            "zoneless": false
+          }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",

--- a/apps/example-app-jest/src/app/examples/15-dialog.component.spec.ts
+++ b/apps/example-app-jest/src/app/examples/15-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { provideZoneChangeDetection } from '@angular/core';
+import { MATERIAL_ANIMATIONS } from '@angular/material/core';
 import { MatDialogRef } from '@angular/material/dialog';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
@@ -12,7 +12,7 @@ test('dialog closes', async () => {
   const closeFn = jest.fn();
   await render(DialogContentComponent, {
     providers: [
-      provideNoopAnimations(),
+      { provide: MATERIAL_ANIMATIONS, useValue: { animationsDisabled: true } },
       {
         provide: MatDialogRef,
         useValue: {
@@ -33,7 +33,7 @@ test('closes the dialog via the backdrop', async () => {
   const user = userEvent.setup();
 
   await render(DialogComponent, {
-    providers: [provideNoopAnimations()],
+    providers: [{ provide: MATERIAL_ANIMATIONS, useValue: { animationsDisabled: true } }],
   });
 
   const openDialogButton = await screen.findByRole('button', { name: /open dialog/i });
@@ -57,7 +57,7 @@ test('opens and closes the dialog with buttons', async () => {
   const user = userEvent.setup();
 
   await render(DialogComponent, {
-    providers: [provideNoopAnimations(), provideZoneChangeDetection()],
+    providers: [{ provide: MATERIAL_ANIMATIONS, useValue: { animationsDisabled: true } }, provideZoneChangeDetection()],
   });
 
   const openDialogButton = await screen.findByRole('button', { name: /open dialog/i });

--- a/apps/example-app-karma/src/test.ts
+++ b/apps/example-app-karma/src/test.ts
@@ -1,7 +1,7 @@
 import 'zone.js';
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 import JasmineDOM from '@testing-library/jasmine-dom';
 
 // Install custom matchers from jasmine-dom
@@ -10,4 +10,4 @@ beforeEach(() => {
 });
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {});
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {});

--- a/apps/example-app/src/app/examples/15-dialog.component.spec.ts
+++ b/apps/example-app/src/app/examples/15-dialog.component.spec.ts
@@ -1,5 +1,5 @@
+import { MATERIAL_ANIMATIONS } from '@angular/material/core';
 import { MatDialogRef } from '@angular/material/dialog';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
@@ -12,7 +12,7 @@ test('dialog closes', async () => {
   const closeFn = vi.fn();
   await render(DialogContentComponent, {
     providers: [
-      provideNoopAnimations(),
+      { provide: MATERIAL_ANIMATIONS, useValue: { animationsDisabled: true } },
       {
         provide: MatDialogRef,
         useValue: {
@@ -32,7 +32,7 @@ test('closes the dialog via the backdrop', async () => {
   const user = userEvent.setup();
 
   await render(DialogComponent, {
-    providers: [provideNoopAnimations()],
+    providers: [{ provide: MATERIAL_ANIMATIONS, useValue: { animationsDisabled: true } }],
   });
 
   const openDialogButton = await screen.findByRole('button', { name: /open dialog/i });
@@ -56,7 +56,7 @@ test('opens and closes the dialog with buttons', async () => {
   const user = userEvent.setup();
 
   await render(DialogComponent, {
-    providers: [provideNoopAnimations()],
+    providers: [{ provide: MATERIAL_ANIMATIONS, useValue: { animationsDisabled: true } }],
   });
 
   const openDialogButton = await screen.findByRole('button', { name: /open dialog/i });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@angular/core": "22.0.2",
     "@angular/material": "22.0.0",
     "@angular/platform-browser": "22.0.2",
-    "@angular/platform-browser-dynamic": "22.0.2",
     "@angular/router": "22.0.2",
     "@ngrx/store": "21.1.0",
     "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "zone.js": "^0.15.1"
   },
   "devDependencies": {
-    "@angular-builders/jest": "^20.0.0",
+    "@angular-builders/jest": "^22.0.1",
     "@angular-devkit/core": "22.0.0",
     "@angular-devkit/schematics": "22.0.0",
     "@angular-eslint/builder": "22.0.0",
@@ -69,7 +69,8 @@
     "jasmine-core": "4.2.0",
     "jasmine-spec-reporter": "7.0.0",
     "jest": "30.2.0",
-    "jest-preset-angular": "^16.0.0",
+    "jest-environment-jsdom": "30.2.0",
+    "jest-preset-angular": "^17.0.0",
     "jsdom": "^27.3.0",
     "karma": "6.4.0",
     "karma-chrome-launcher": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "prepare": "git config core.hookspath .githooks"
   },
   "dependencies": {
-    "@angular/animations": "22.0.2",
     "@angular/cdk": "22.0.0",
     "@angular/common": "22.0.2",
     "@angular/compiler": "22.0.2",


### PR DESCRIPTION
- Swap provideNoopAnimations() for Material's MATERIAL_ANIMATIONS token in dialog specs (provideNoopAnimations is deprecated since v20.2)
- Swap BrowserDynamicTestingModule/platformBrowserDynamicTesting for BrowserTestingModule/platformBrowserTesting in karma test.ts, and drop the now-unused @angular/platform-browser-dynamic dependency